### PR TITLE
Speed-Up Pre-Computation of U-Update Matrix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,9 +4,8 @@ Title: Convex (Bi)Clustering via Algorithmic Regularization Paths
 Version: 0.1.0
 Authors@R: c(
   person("John", "Nagorski", role = c("aut", "cre"), email = "jn13@rice.edu"),
-  person("Michael", "Weylandt", role=c("ctb"),email="Michael.Weylandt@rice.edu"),
-  person("Genevera","Allen",role=c("ths"),email="gallen@rice.edu"))
-Maintainer: John Nagorski <jn13@rice.edu>
+  person("Michael", "Weylandt", role = "ctb", email = "Michael.Weylandt@rice.edu"),
+  person("Genevera","Allen", role = "ths", email = "gallen@rice.edu"))
 Description: Provides interactive graphics and fast computation for the Convex Clustering problem.
 License: GPL-3
 Encoding: UTF-8
@@ -19,7 +18,6 @@ Imports:
     Rcpp, 
     stats,
     graphics,
-    parallel,
     dplyr,
     ggplot2,
     tidyr,

--- a/R/carp.R
+++ b/R/carp.R
@@ -114,7 +114,6 @@ CARP <- function(X,
   weights <- internal.control$weights
   weight.dist <- internal.control$weight.dist
   weight.dist.p <- internal.control$weight.dist.p
-  ncores <- internal.control$ncores
   max.iter <- internal.control$max.iter
   burn.in <- internal.control$burn.in
   alg.type <- internal.control$alg.type
@@ -216,7 +215,6 @@ CARP <- function(X,
   PreCompList <- suppressMessages(ConvexClusteringPreCompute(
     X = X,
     weights = weights,
-    ncores = ncores,
     rho = rho
   ))
   cardE <- NROW(PreCompList$E)
@@ -371,7 +369,6 @@ CARP <- function(X,
 #'                      \code{weight.dist = "minkowski"}.
 #'                      See \code{\link[stats]{dist}} for details.
 #' @param phi A positive real number: the scale factor used in the RBF kernel
-#' @param ncores An positive integer: the number of cores to use.
 #' @param max.iter An integer: the maximum number of CARP iterations.
 #' @param burn.in An integer: the number of initial iterations at a fixed
 #'                (small) value of \eqn{\lambda}
@@ -402,7 +399,6 @@ carp.control <- function(obs.labels = NULL,
                          k = NULL,
                          weight.dist = "euclidean",
                          weight.dist.p = 2,
-                         ncores = 1L,
                          max.iter = 1000000L,
                          burn.in = 50L,
                          alg.type = "carpviz",
@@ -446,10 +442,6 @@ carp.control <- function(obs.labels = NULL,
     stop(sQuote("weight.dist.p"),
          " must be a positive scalar; see the ", sQuote("p"),
          " argument of ", sQuote("stats::dist"), " for details.")
-  }
-
-  if (!is.integer(ncores) || ncores <= 0L) {
-    stop(sQuote("ncores"), " must be a positive integer.")
   }
 
   if (!is.null(npcs)) {
@@ -497,7 +489,6 @@ carp.control <- function(obs.labels = NULL,
     weights = weights,
     weight.dist = weight.dist,
     weight.dist.p = weight.dist.p,
-    ncores = ncores,
     max.iter = max.iter,
     burn.in = burn.in,
     alg.type = alg.type,

--- a/R/cbass.R
+++ b/R/cbass.R
@@ -125,7 +125,6 @@ CBASS <- function(X,
   var.weight.dist <- internal.control$var.weight.dist
   obs.weight.dist.p <- internal.control$obs.weight.dist.p
   var.weight.dist.p <- internal.control$var.weight.dist.p
-  ncores <- internal.control$ncores
   max.iter <- internal.control$max.iter
   burn.in <- internal.control$burn.in
   alg.type <- internal.control$alg.type
@@ -208,7 +207,7 @@ CBASS <- function(X,
     ConvexClusteringPreCompute(
       X = t(X),
       weights = weights.row,
-      ncores = ncores, rho = rho
+      rho = rho
     )
   )
   cardE.row <- NROW(PreCompList.row$E)
@@ -236,7 +235,7 @@ CBASS <- function(X,
     ConvexClusteringPreCompute(
       X = X,
       weights = weights.col,
-      ncores = ncores, rho = rho
+      rho = rho
     )
   )
   cardE.col <- NROW(PreCompList.col$E)
@@ -406,7 +405,6 @@ CBASS <- function(X,
 #' @param var.weight.dist.p The exponent used to calculate the Minkowski distance if
 #'                          \code{weight.dist = "minkowski"}.
 #'                          See \code{\link[stats]{dist}} for details.
-#' @param ncores An positive integer: the number of cores to use.
 #' @param max.iter An integer: the maximum number of CARP iterations.
 #' @param burn.in An integer: the number of initial iterations at a fixed
 #'                (small) value of \eqn{\lambda}
@@ -438,7 +436,6 @@ cbass.control <- function(obs.labels = NULL,
                           k.obs = NULL,
                           k.var = NULL,
                           t = 1.01,
-                          ncores = as.integer(1),
                           max.iter = as.integer(1e6),
                           burn.in = as.integer(50),
                           alg.type = "cbassviz",
@@ -505,10 +502,6 @@ cbass.control <- function(obs.labels = NULL,
     }
   }
 
-  if (!is.integer(ncores) || ncores <= 0L) {
-    stop(sQuote("ncores"), " must be a positive integer.")
-  }
-
   if (!is.null(npcs)) {
     if (!is.integer(npcs) || npcs <= 1L) {
       stop(sQuote("npcs"), " must be at least 2.")
@@ -546,7 +539,6 @@ cbass.control <- function(obs.labels = NULL,
     k.obs = k.obs,
     k.var = k.var,
     t = t,
-    ncores = ncores,
     max.iter = max.iter,
     burn.in = burn.in,
     alg.type = alg.type


### PR DESCRIPTION
This is a micro-optimization to speed-up the calls to `ConvexClusteringPreCompute`. I used the same check as in #6, namely, checking that the result of: 

```
carp_test <- list(
  CARPVIZ   = CARP(presidential_speech, static = FALSE, interactive = FALSE, alg.type="carpviz")$carp.sol.path, 
  CARP1.2   = CARP(presidential_speech, static = FALSE, interactive = FALSE, alg.type="carp", t=1.2)$carp.sol.path, 
  CARP1.1   = CARP(presidential_speech, static = FALSE, interactive = FALSE, alg.type="carp", t=1.1)$carp.sol.path, 
  CARP1.05  = CARP(presidential_speech, static = FALSE, interactive = FALSE, alg.type="carp", t=1.05)$carp.sol.path, 
  CBASSVIZ  = CBASS(presidential_speech, static = FALSE, interactive = FALSE, alg.type="cbassviz")$cbass.sol.path, 
  CBASS1.2  = CBASS(presidential_speech, static = FALSE, interactive = FALSE, alg.type="cbass", t=1.2)$cbass.sol.path, 
  CBASS1.1  = CBASS(presidential_speech, static = FALSE, interactive = FALSE, alg.type="cbass", t=1.1)$cbass.sol.path, 
  CBASS1.05 = CBASS(presidential_speech, static = FALSE, interactive = FALSE, alg.type="cbass", t=1.05)$cbass.sol.path
)
```

is unchanged. 

Calculating the above takes about 22.2 seconds now, as opposed to 36.4 seconds before this PR. That's a savings of approximately 1 second per call to `ConvexClusteringPreCompute` (`CBASS` calls it twice). 

The trick is to take advantage of Kronecker product algebra: $(A + B) \otimes C = A \otimes B + A \otimes C$. This lets us replace `cardE` calls to `kronecker` with a single call. 

I've also pulled out any references to `ncores` since it doesn't seem useful now. 