### PR TITLE
Speed up CARP post-processing

### DIFF
--- a/R/carp.R
+++ b/R/carp.R
@@ -43,7 +43,7 @@
 #'         \item \code{interactive}: a logical indicating whether interactive visualizations are available for this \code{CARP} object
 #'         }
 #' @importFrom utils data
-#' @importFrom dplyr %>%
+#' @importFrom dplyr %>% bind_rows
 #' @importFrom dplyr n
 #' @importFrom dplyr tbl_df
 #' @importFrom dplyr mutate
@@ -312,9 +312,7 @@ CARP <- function(X,
           Lambda = carp.cluster.path$lambda.path.inter[iter],
           ObsLabel = n.labels
         )
-    }) %>%
-      do.call(rbind.data.frame, .) %>%
-      dplyr::tbl_df() %>%
+    }) %>% bind_rows %>%
       dplyr::group_by(Iter) %>%
       dplyr::mutate(
         NCluster = length(unique(Cluster))


### PR DESCRIPTION
  Replace `do.call(rbind.data.frame, LIST)` with
  `dplyr::bind_rows(LIST)`

  This change passes the `all.equal` test on the
  output of
 
   ```
  carp_test <- list(
    CARPVIZ   = CARP(presidential_speech, alg.type="carpviz"),
    CARP1.2   = CARP(presidential_speech, alg.type="carp", t=1.2),
    CARP1.1   = CARP(presidential_speech, alg.type="carp", t=1.1),
    CARP1.05  = CARP(presidential_speech, alg.type="carp", t=1.05))
   ```

  and saves about 2 seconds off the total run time, so around 500ms per `CARP` call