### PR TITLE
Speed Up Cluster Assignment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ r_packages:
   - igraph
   - gtools
   - tidyr
-  - plyr
 
 before_install:
   - gcc --version

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,6 @@ Imports:
     purrr,
     shiny,
     Matrix,
-    plyr,
     stringr,
     zoo,
     animation,

--- a/R/carp.R
+++ b/R/carp.R
@@ -277,15 +277,10 @@ CARP <- function(X,
     lambda.path = carp.sol.path$lambda.path,
     cardE = cardE
   ) -> carp.cluster.path
-  carp.cluster.path$sp.path.inter %>% duplicated(fromLast = FALSE) -> sp.path.dups
-  adj.path <- CreateAdjacencyPath(PreCompList$E, sp.path = carp.cluster.path$sp.path.inter, n.obs)
-  clust.graph.path <- CreateClusterGraphPath(adj.path)
-  clust.path <- GetClustersPath(clust.graph.path)
+
+  clust.path <- get_cluster_assignments(PreCompList$E, carp.cluster.path$sp.path.inter, n.obs)
   clust.path.dups <- duplicated(clust.path, fromLast = FALSE)
 
-  carp.cluster.path[["sp.path.dups"]] <- sp.path.dups
-  carp.cluster.path[["adj.path"]] <- adj.path
-  carp.cluster.path[["clust.graph.path"]] <- clust.graph.path
   carp.cluster.path[["clust.path"]] <- clust.path
   carp.cluster.path[["clust.path.dups"]] <- clust.path.dups
 

--- a/R/cbass.R
+++ b/R/cbass.R
@@ -240,7 +240,7 @@ CBASS <- function(X,
   )
   cardE.col <- NROW(PreCompList.col$E)
 
-  if (verbose.basic) message("Computing CBASS Path\n")
+  if (verbose.basic) message("Computing CBASS Path")
 
   if (alg.type %in% c("cbassviz", "cbassvizl1")) {
     bicarp.sol.path <- CBASS_VIZcpp(x = X[TRUE],
@@ -304,7 +304,8 @@ CBASS <- function(X,
   ##         the type here for now
   bicarp.sol.path$lambda.path <- matrix(bicarp.sol.path$lambda.path, ncol=1)
 
-  if (verbose.basic) message("Post-processing\n")
+  if (verbose.basic) message("Post-processing")
+
   ISP(
     sp.path = bicarp.sol.path$v.row.zero.inds %>% t(),
     v.path = bicarp.sol.path$v.row.path,
@@ -312,21 +313,14 @@ CBASS <- function(X,
     lambda.path = bicarp.sol.path$lambda.path,
     cardE = sum(weights.row != 0)
   ) -> bicarp.cluster.path.row
-  bicarp.cluster.path.row$sp.path.inter %>% duplicated(fromLast = FALSE) -> sp.path.dups.row
-  adj.path.row <- CreateAdjacencyPath(PreCompList.row$E, sp.path = bicarp.cluster.path.row$sp.path.inter, p.var)
-  clust.graph.path.row <- CreateClusterGraphPath(adj.path.row)
-  clust.path.row <- GetClustersPath(clust.graph.path.row)
+
+  clust.path.row <- get_cluster_assignments(PreCompList.row$E, bicarp.cluster.path.row$sp.path.inter, p.var)
   clust.path.dups.row <- duplicated(clust.path.row, fromLast = FALSE)
 
-  bicarp.cluster.path.row[["sp.path.dups"]] <- sp.path.dups.row
-  bicarp.cluster.path.row[["adj.path"]] <- adj.path.row
-  bicarp.cluster.path.row[["clust.graph.path"]] <- clust.graph.path.row
   bicarp.cluster.path.row[["clust.path"]] <- clust.path.row
   bicarp.cluster.path.row[["clust.path.dups"]] <- clust.path.dups.row
 
   bicarp.dend.row <- CreateDendrogram(bicarp.cluster.path.row, p.labels)
-
-
 
   ISP(
     sp.path = bicarp.sol.path$v.col.zero.inds %>% t(),
@@ -335,19 +329,15 @@ CBASS <- function(X,
     lambda.path = bicarp.sol.path$lambda.path,
     cardE = sum(weights.col != 0)
   ) -> bicarp.cluster.path.col
-  bicarp.cluster.path.col$sp.path.inter %>% duplicated(fromLast = FALSE) -> sp.path.dups.col
-  adj.path.col <- CreateAdjacencyPath(PreCompList.col$E, sp.path = bicarp.cluster.path.col$sp.path.inter, n.obs)
-  clust.graph.path.col <- CreateClusterGraphPath(adj.path.col)
-  clust.path.col <- GetClustersPath(clust.graph.path.col)
+
+  clust.path.col <- get_cluster_assignments(PreCompList.col$E, bicarp.cluster.path.col$sp.path.inter, n.obs)
   clust.path.dups.col <- duplicated(clust.path.col, fromLast = FALSE)
 
-  bicarp.cluster.path.col[["sp.path.dups"]] <- sp.path.dups.col
-  bicarp.cluster.path.col[["adj.path"]] <- adj.path.col
-  bicarp.cluster.path.col[["clust.graph.path"]] <- clust.graph.path.col
   bicarp.cluster.path.col[["clust.path"]] <- clust.path.col
   bicarp.cluster.path.col[["clust.path.dups"]] <- clust.path.dups.col
 
   bicarp.dend.col <- CreateDendrogram(bicarp.cluster.path.col, n.labels)
+
   cbass.fit <- list(
     X = X.orig,
     cbass.sol.path = bicarp.sol.path,

--- a/R/utils.R
+++ b/R/utils.R
@@ -23,26 +23,14 @@ CreateAdjacency <- function(E, sp.pattern, n) {
   adjmat@x <- as.double(rep(1, times = nrow(connected.pairs)))
   return(adjmat)
 }
-CreateAdjacencyPath <- function(E, sp.path, n) {
-  lapply(1:nrow(sp.path), function(x) {
-    CreateAdjacency(E, sp.path[x, ], n)
-  })
-}
+
 CreateClusterGraph <- function(AdjMatrix) {
   igraph::graph_from_adjacency_matrix(AdjMatrix, mode = "undirected")
-}
-CreateClusterGraphPath <- function(AdjMatrixList) {
-  lapply(AdjMatrixList, function(x) {
-    CreateClusterGraph(x)
-  })
 }
 
 #' @importFrom igraph components
 GetClusters <- function(ClusterGraph) {
   igraph::components(ClusterGraph)
-}
-GetClustersPath <- function(ClusterGraphList) {
-  lapply(ClusterGraphList, GetClusters)
 }
 
 #' @importFrom Matrix which

--- a/build_steps.R
+++ b/build_steps.R
@@ -8,7 +8,7 @@ before_install <- function(){
   }
   cat("INSTALLING RUN DEPENDENCIES -------- \n\n")
   devtools::install_deps(dependencies=c("Depends", "Imports", "LinkingTo", "Suggests", "Enhances"),
-                         quiet=FALSE, upgrade=TRUE)
+                         quiet=FALSE, upgrade=FALSE)
 
   cat("BUILDING NAMESPACE with roxygen2 -------- \n\n")
   roxygen2::roxygenize()

--- a/src/clustRviz.h
+++ b/src/clustRviz.h
@@ -1,4 +1,6 @@
 #include <RcppEigen.h>
+#include <vector>
+#include <set>
 
 #define CLUSTRVIZ_CHECK_USER_INTERRUPT_RATE 50
 
@@ -13,6 +15,16 @@ T_full extract(const T_full& full, const T_ind& ind){
   }
 
   return target;
+}
+
+// Helper to determine if STL set contains an element
+//
+// In general, this is not efficient because one wants to do something
+// with the element and/or its location, but here we really only need containment
+template <typename T>
+bool contains(const std::set<T>& container, T element){
+  typename std::set<T>::const_iterator it = container.find(element);
+  return it != container.end();
 }
 
 // Prototypes - Eigen implementations

--- a/src/get_cluster_assignments.cpp
+++ b/src/get_cluster_assignments.cpp
@@ -1,0 +1,175 @@
+#include "clustRviz.h"
+
+Rcpp::List get_cluster_assignments_impl(const Eigen::MatrixXi& E,
+                                        const Eigen::VectorXi& edge_ind,
+                                        int n){
+
+  // We use a simple (depth-first?) search to determine the connected components
+  // of the graphs. Since we frequently need to check if a vertex is in a component,
+  // we represent each component as a std::set<int>, and we store the components
+  // in a std::vector
+  std::vector<std::set<int> > components;
+
+  // Iterate over all possible edges - this big loop is a no-op where edge_ind == 0
+  for(Eigen::Index i = 0; i < edge_ind.size(); i++){
+
+    if(edge_ind(i) != 0){ // If the edge is present
+      int edge_begin = E(i, 0);
+      int edge_end   = E(i, 1);
+
+      // We begin by looking for the first vertex (here called "begin") in each component
+      bool found_component_begin = false;
+
+      for(Eigen::Index j = 0; j < components.size(); j++){
+        std::set<int>& component_j = components[j];
+
+        if(contains(component_j, edge_begin)){
+          // Once we found a component containing the "begin" vertex, let's see if
+          // it contains the "end" vertex.
+          found_component_begin = true;
+          bool found_component_end = false;
+
+          // If begin and end are already in the same component, we don't need
+          // to do anything.
+          if(contains(component_j, edge_end)){
+            found_component_end = true;
+            break; // Continue to next edge
+          }
+
+          // Now check other components
+          for(Eigen::Index k = 0; k < components.size(); k++){
+            if(k != j){ // We handled k == j above
+
+              std::set<int>& component_k = components[k];
+
+              if(contains(component_k, edge_end)){
+                found_component_end = true;
+                // This implies components j and k are connected, but weren't already
+                //
+                // First we copy all the elements of component_k into component_j
+                component_j.insert(component_k.begin(), component_k.end());
+                // Now we drop component k
+                components.erase(components.begin() + k);
+                break; // No need to check other components
+              }
+            }
+          }
+
+          // If we never found `edge_end` in any component, we add it to component J
+          // since it is connected to `edge_begin.`
+          if(!found_component_end){
+            component_j.insert(edge_end);
+          }
+
+          break; // No need to check other components,
+                 // since edge_begin can only be in one component
+        }
+      }
+
+      // If we didnt' find edge_begin in any component, we first check for edge_begin
+      if(!found_component_begin){
+
+        // First check if edge_end is anywhere:
+        // If it is, then we add edge_begin to the same component
+        bool found_component_end_inner = false;
+
+        for(Eigen::Index j = 0; j < components.size(); j++){
+          std::set<int>& component_j = components[j];
+          if(contains(component_j, edge_end)){
+            // We didn't find edge_begin, but we do have edge_end, so let's add
+            // edge_begin to the same component
+            component_j.insert(edge_begin);
+            found_component_end_inner = true;
+            break;
+          }
+        }
+
+        // If we can't find edge_begin or edge_end anywhere, they are both new
+        // and get there own new component
+        if(!found_component_end_inner){
+          std::set<int> new_component{edge_begin, edge_end};
+          components.push_back(new_component);
+        }
+      }
+    }
+  }
+
+  // Sort components in decreasing size order
+  std::sort(components.begin(),
+            components.end(),
+            [](const std::set<int>& left, const std::set<int>& right){
+               return left.size() > right.size();
+              });
+
+  // Now build things in a way that works for R
+  //
+  // The total number of components is given by components.size() +
+  // any extra (isolated / untouched) vertices
+  //
+  // The number of isolated vertices
+  int num_vertices_seen = 0;
+  for(std::set<int>& component : components){
+    num_vertices_seen += component.size();
+  }
+  int num_components = components.size() + n - num_vertices_seen;
+
+  Rcpp::IntegerVector component_sizes(num_components, 1);
+  Rcpp::IntegerVector component_indicators(n, -1);
+
+  int num_components_seen = 0;
+  for(Eigen::Index i = 0; i < components.size(); i++){
+    num_components_seen += 1;
+    std::set<int> component_i = components[i];
+    component_sizes[i] = component_i.size();
+
+    for(int j : component_i){
+      component_indicators[j - 1] = i + 1; // j - 1 because edges are 1-indexed (coming form R)
+                                           // Similarly, we start counting components at 1
+    }
+  }
+
+  // Finally, we go through and set all of the "-1" elements to a positive
+  // number for unitary components = isolated vertices
+  for(Eigen::Index i = 0; i < n; i++){
+    if(component_indicators(i) == -1){
+      num_components_seen += 1;
+      component_indicators(i) = num_components_seen;
+    }
+  }
+
+  return Rcpp::List::create(Rcpp::Named("membership") = Rcpp::wrap(component_indicators),
+                            Rcpp::Named("csize") = Rcpp::wrap(component_sizes),
+                            Rcpp::Named("no") = Rcpp::wrap(num_components));
+}
+
+// Get cluster assignments
+//
+// Given the output of CARP/CBASS (in vectorized form), perform the actual cluster
+// assignments
+//
+// Input: E - a two column matrix with the edge set used for clustering.
+//            (The i-th row is (j, k) if there is an edge between j and k)
+//        edge_ind - A 0/1 matrix with NCOL(edge_ind) == NROW(E)
+//                   Element (i, j) is 1 if the j-th edge (as defined by E)
+//                   was "active" in the i-th stage of clustering. (I.e., were those
+//                   two elements fused together). Each row is one iteration of CARP/CBASS
+//        n - the number of observations
+//
+// Output - A list of NROW(edge_ind) `Rcpp::List`s, each of which has the
+//          following elements:
+//            - membership - an `Rcpp::IntegerVector` with cluster labels
+//            - csize      - The number of elements in each cluster
+//            - no         - the number of clutsers
+// TODO: Do we need all three of these?
+// [[Rcpp::export]]
+Rcpp::List get_cluster_assignments(const Eigen::MatrixXi& E,
+                                   const Eigen::MatrixXi& edge_ind,
+                                   int n){
+  Rcpp::List return_object(edge_ind.rows());
+
+  for(Eigen::Index i = 0; i < edge_ind.rows(); i++){
+    return_object[i] = get_cluster_assignments_impl(E, edge_ind.row(i), n);
+  }
+
+  return return_object;
+}

--- a/tests/testthat/test_clustering_assignments_cpp.R
+++ b/tests/testthat/test_clustering_assignments_cpp.R
@@ -1,0 +1,169 @@
+context("Test Clustering Assignments")
+
+test_that("Star graph clustering works", {
+  get_cluster_assignments <- clustRviz:::get_cluster_assignments
+  n <- 5
+  E <- matrix(c(1, 2, ## This checks fusing beginnings to beginnings
+                1, 3,
+                1, 4,
+                1, 5), ncol=2, byrow=TRUE)
+
+  ## Fully clustered
+  edge_indicator <- matrix(c(1, 1, 1, 1), nrow=1)
+  cluster_assignment <- get_cluster_assignments(E, edge_indicator, n)[[1]]
+  expect_equal(cluster_assignment$no, 1)
+  expect_equal(cluster_assignment$csize, 5)
+  expect_equal(cluster_assignment$membership, rep(1, 5))
+
+  ## No clustering
+  edge_indicator <- matrix(c(0, 0, 0, 0), nrow=1)
+  cluster_assignment <- get_cluster_assignments(E, edge_indicator, n)[[1]]
+  expect_equal(cluster_assignment$no, 5)
+  expect_equal(cluster_assignment$csize, rep(1, 5))
+  expect_equal(cluster_assignment$membership, seq(1, 5))
+
+  ## Partial clustering
+  edge_indicator <- matrix(c(1, 1, 0, 0), nrow=1)
+  cluster_assignment <- get_cluster_assignments(E, edge_indicator, n)[[1]]
+  expect_equal(cluster_assignment$no, 3)
+  expect_equal(cluster_assignment$csize, c(3, 1, 1))
+  expect_equal(cluster_assignment$membership, c(1, 1, 1, 2, 3))
+})
+
+test_that("Chain graph clustering works", {
+  get_cluster_assignments <- clustRviz:::get_cluster_assignments
+  n <- 5
+  E <- matrix(c(1, 2, ## This checks fusing beginnings to ends
+                2, 3,
+                3, 4,
+                4, 5), ncol=2, byrow=TRUE)
+
+  ## Fully clustered
+  edge_indicator <- matrix(c(1, 1, 1, 1), nrow=1)
+  cluster_assignment <- get_cluster_assignments(E, edge_indicator, n)[[1]]
+  expect_equal(cluster_assignment$no, 1)
+  expect_equal(cluster_assignment$csize, 5)
+  expect_equal(cluster_assignment$membership, rep(1, 5))
+
+  ## No clustering
+  edge_indicator <- matrix(c(0, 0, 0, 0), nrow=1)
+  cluster_assignment <- get_cluster_assignments(E, edge_indicator, n)[[1]]
+  expect_equal(cluster_assignment$no, 5)
+  expect_equal(cluster_assignment$csize, rep(1, 5))
+  expect_equal(cluster_assignment$membership, seq(1, 5))
+
+  ## Partial clustering
+  edge_indicator <- matrix(c(1, 0, 0, 1), nrow=1)
+  cluster_assignment <- get_cluster_assignments(E, edge_indicator, n)[[1]]
+  expect_equal(cluster_assignment$no, 3)
+  expect_equal(cluster_assignment$csize, c(2, 2, 1)) # Singleton is cluster #3 (final cluster)
+  expect_equal(cluster_assignment$membership, c(1, 1, 3, 2, 2))
+})
+
+test_that("Disconnected graph doesn't cluster", {
+  # This shouldn't happen in clustRviz, but our code can handle it
+  get_cluster_assignments <- clustRviz:::get_cluster_assignments
+  n <- 6
+  E <- matrix(c(1, 2,
+                2, 3,
+                4, 5,
+                5, 6), ncol=2, byrow=TRUE)
+
+  edge_indicator <- matrix(c(1, 1, 1, 1), nrow=1)
+  cluster_assignment <- get_cluster_assignments(E, edge_indicator, n)[[1]]
+  expect_equal(cluster_assignment$no, 2)
+  expect_equal(cluster_assignment$csize, c(3, 3))
+  expect_equal(cluster_assignment$membership, c(1, 1, 1, 2, 2, 2))
+})
+
+test_that("Clusters get merged when only ends are shared", {
+  # This shouldn't happen in clustRviz, but our code can handle it
+  get_cluster_assignments <- clustRviz:::get_cluster_assignments
+  n <- 5
+  E <- matrix(c(1, 5,
+                2, 5,
+                3, 4), ncol=2, byrow=TRUE)
+
+  edge_indicator <- matrix(c(1, 1, 1), nrow=1)
+  cluster_assignment <- get_cluster_assignments(E, edge_indicator, n)[[1]]
+  expect_equal(cluster_assignment$no, 2)
+  expect_equal(cluster_assignment$csize, c(3, 2))
+  expect_equal(cluster_assignment$membership, c(1, 1, 2, 2, 1))
+
+  ## Add some singletons
+  n <- 7
+  cluster_assignment <- get_cluster_assignments(E, edge_indicator, n)[[1]]
+  expect_equal(cluster_assignment$no, 4)
+  expect_equal(cluster_assignment$csize, c(3, 2, 1, 1))
+  expect_equal(cluster_assignment$membership, c(1, 1, 2, 2, 1, 3, 4))
+})
+
+test_that("Functionality works row-wise", {
+  set.seed(25)
+  get_cluster_assignments <- clustRviz:::get_cluster_assignments
+
+  n <- 50
+  k <- 20
+  E <- matrix(sample(n, 2 * k, replace = TRUE), ncol=2)
+  E <- unique(E)
+
+  edge_indicator <- matrix(rbinom(NROW(E) * 5, size=1, prob=0.5), ncol=NROW(E))
+
+  expect_equal(get_cluster_assignments(E, edge_indicator, n),
+               lapply(1:5, function(i) get_cluster_assignments(E, edge_indicator[i, , drop=FALSE], n)[[1]]))
+})
+
+test_that("Cluster sizes are decreasing", {
+  set.seed(125)
+  get_cluster_assignments <- clustRviz:::get_cluster_assignments
+
+  n <- 40
+  k <- 30
+  E <- matrix(sample(n, 2 * k, replace = TRUE), ncol=2)
+  E <- unique(E)
+
+  edge_indicator <- matrix(rbinom(NROW(E) * 50, size=1, prob=0.5), ncol=NROW(E))
+
+  cluster_assignments <- get_cluster_assignments(E, edge_indicator, n)
+
+  is_decreasing <- function(x) all(x == cummin(x))
+  expect_true(all(vapply(cluster_assignments, function(x) is_decreasing(x$csize), logical(1))))
+})
+
+test_that("Cluster labels are sequential (no gaps)", {
+  set.seed(500)
+  get_cluster_assignments <- clustRviz:::get_cluster_assignments
+
+  n <- 400
+  k <- 200
+  E <- matrix(sample(n, 2 * k, replace = TRUE), ncol=2)
+  E <- unique(E)
+
+  edge_indicator <- matrix(rbinom(NROW(E) * 50, size=1, prob=0.5), ncol=NROW(E))
+
+  cluster_assignments <- get_cluster_assignments(E, edge_indicator, n)
+
+  has_unique_labels <- function(x){
+    num_unique <- length(unique(x))
+    all(seq_len(num_unique) %in% x) && all(x %in% seq_len(num_unique))
+  }
+  expect_true(all(vapply(cluster_assignments, function(x) has_unique_labels(x$membership), logical(1))))
+})
+
+test_that("Number of clusters is correctly calculated", {
+  set.seed(750)
+  get_cluster_assignments <- clustRviz:::get_cluster_assignments
+
+  n <- 400
+  k <- 200
+  E <- matrix(sample(n, 2 * k, replace = TRUE), ncol=2)
+  E <- unique(E)
+
+  edge_indicator <- matrix(rbinom(NROW(E) * 50, size=1, prob=0.75), ncol=NROW(E))
+
+  cluster_assignments <- get_cluster_assignments(E, edge_indicator, n)
+
+  expect_true(all(vapply(cluster_assignments,
+                         function(x) (x$no == length(unique(x$membership))) && (x$no == length(x$csize)),
+                         logical(1))))
+})

--- a/tests/testthat/test_clustering_assignments_cpp.R
+++ b/tests/testthat/test_clustering_assignments_cpp.R
@@ -56,8 +56,8 @@ test_that("Chain graph clustering works", {
   edge_indicator <- matrix(c(1, 0, 0, 1), nrow=1)
   cluster_assignment <- get_cluster_assignments(E, edge_indicator, n)[[1]]
   expect_equal(cluster_assignment$no, 3)
-  expect_equal(cluster_assignment$csize, c(2, 2, 1)) # Singleton is cluster #3 (final cluster)
-  expect_equal(cluster_assignment$membership, c(1, 1, 3, 2, 2))
+  expect_equal(cluster_assignment$csize, c(2, 1, 2))
+  expect_equal(cluster_assignment$membership, c(1, 1, 2, 3, 3))
 })
 
 test_that("Disconnected graph doesn't cluster", {
@@ -113,7 +113,11 @@ test_that("Functionality works row-wise", {
                lapply(1:5, function(i) get_cluster_assignments(E, edge_indicator[i, , drop=FALSE], n)[[1]]))
 })
 
-test_that("Cluster sizes are decreasing", {
+test_that("Cluster labels are increasing", {
+  ## For stability, we require the cluster labels to be assigned in increasing order
+  ##
+  ## That is, if we get the smallest index for each cluster, those indices should be
+  ## increasing
   set.seed(125)
   get_cluster_assignments <- clustRviz:::get_cluster_assignments
 
@@ -126,8 +130,9 @@ test_that("Cluster sizes are decreasing", {
 
   cluster_assignments <- get_cluster_assignments(E, edge_indicator, n)
 
-  is_decreasing <- function(x) all(x == cummin(x))
-  expect_true(all(vapply(cluster_assignments, function(x) is_decreasing(x$csize), logical(1))))
+  is_increasing <- function(x) all(x == cummax(x))
+  unique_increasing <- function(x) is_increasing(unique(x))
+  expect_true(all(vapply(cluster_assignments, function(x) unique_increasing(x$membership), logical(1))))
 })
 
 test_that("Cluster labels are sequential (no gaps)", {


### PR DESCRIPTION
As discussed, the previous approach to assigning cluster labels required translating between several different data structures (as well as several `lapply` calls) so it was slower than it should have been. This PR adds a dedicated C++ routine to assign cluster labels. 

In quick tests: 

```
list(
  CARPVIZ   = CARP(presidential_speech, alg.type="carpviz"), 
  CARP1.2   = CARP(presidential_speech, alg.type="carp", t=1.2), 
  CARP1.1   = CARP(presidential_speech, alg.type="carp", t=1.1), 
  CARP1.05  = CARP(presidential_speech, alg.type="carp", t=1.05), 
  CBASSVIZ  = CBASS(presidential_speech, alg.type="cbassviz"), 
  CBASS1.2  = CBASS(presidential_speech, alg.type="cbass", t=1.2), 
  CBASS1.1  = CBASS(presidential_speech, alg.type="cbass", t=1.1), 
  CBASS1.05 = CBASS(presidential_speech, alg.type="cbass", t=1.05)
)
```

now takes 16.2 seconds instead of 24.4 seconds, so it's a non-trivial speed-up.

This PR also removes extraneous computed quantities (i.e., the list of adjacency matrices for each step), so I can't do an easy `all.equal` test on the above. 

Any thoughts on how to test? 

Once this and #7 are merged, we can drop the `igraph` dependency and cut on some more utility functions.