### PR TITLE
Fix Transpose in clustering.CBASS

### DIFF
--- a/R/get_clusters.R
+++ b/R/get_clusters.R
@@ -225,32 +225,30 @@ clustering.CBASS <- function(x, k.obs = NULL, k.var = NULL, percent = NULL, ...)
   } else {
     stop("Select exactly one of k.obs, k.var, or percent")
   }
-  # find lambda closest in column path
-  cur.col.lam.ind <- which.min(abs(x$cbass.cluster.path.obs$lambda.path.inter - cur.lam))
-  # find clustering solution in column path
-  cur.col.clust.assignment <- x$cbass.cluster.path.obs$clust.path[[cur.col.lam.ind]]$membership
-  cur.col.clust.labels <- unique(cur.col.clust.assignment)
-  cur.col.nclust <- length(cur.col.clust.labels)
-  # find lambda closest in row path
-  cur.row.lam.ind <- which.min(abs(x$cbass.cluster.path.var$lambda.path.inter - cur.lam))
-  # find clustering solution in row path
-  cur.row.clust.assignment <- x$cbass.cluster.path.var$clust.path[[cur.row.lam.ind]]$membership
+  # find lambda closest in row (observation) path
+  cur.row.lam.ind <- which.min(abs(x$cbass.cluster.path.obs$lambda.path.inter - cur.lam))
+  # find clustering solution in row (observation) path
+  cur.row.clust.assignment <- x$cbass.cluster.path.obs$clust.path[[cur.row.lam.ind]]$membership
   cur.row.clust.labels <- unique(cur.row.clust.assignment)
   cur.row.nclust <- length(cur.row.clust.labels)
+  # find lambda closest in column (variable) path
+  cur.col.lam.ind <- which.min(abs(x$cbass.cluster.path.var$lambda.path.inter - cur.lam))
+  # find clustering solution in column (variable) path
+  cur.col.clust.assignment <- x$cbass.cluster.path.var$clust.path[[cur.col.lam.ind]]$membership
+  cur.col.clust.labels <- unique(cur.col.clust.assignment)
+  cur.col.nclust <- length(cur.col.clust.labels)
 
   if (x$X.center.global) {
     X.heat <- x$X
     X.heat <- X.heat - mean(X.heat)
-    X.heat <- t(X.heat)
     X <- x$X
     X <- X - mean(X)
-    X <- t(X)
   } else {
-    X.heat <- t(x$X)
-    X <- t(x$X)
+    X.heat <- x$X
+    X <- x$X
   }
-  colnames(X.heat) <- x$obs.labels
-  rownames(X.heat) <- x$var.labels
+  rownames(X.heat) <- x$obs.labels
+  colnames(X.heat) <- x$var.labels
   for (col.label.ind in seq_along(cur.col.clust.labels)) {
     cur.col.label <- cur.col.clust.labels[col.label.ind]
     col.inds <- which(cur.col.clust.assignment == cur.col.label)
@@ -263,11 +261,12 @@ clustering.CBASS <- function(x, k.obs = NULL, k.var = NULL, percent = NULL, ...)
   }
 
 
-  clust.assign.obs <- paste("cl", cur.col.clust.assignment, sep = "")
-  clust.assign.var <- paste("cl", cur.row.clust.assignment, sep = "")
+  clust.assign.obs <- paste("cl", cur.row.clust.assignment, sep = "")
+  clust.assign.var <- paste("cl", cur.col.clust.assignment, sep = "")
   list(
     clustering.assignment.obs = clust.assign.obs,
     clustering.assignment.var = clust.assign.var,
     cluster.mean.matrix = X.heat
   )
+
 }

--- a/tests/testthat/testCBASS.R
+++ b/tests/testthat/testCBASS.R
@@ -123,7 +123,54 @@ test_that("clustering CBASS  Runs percent=.3",{
   )
 })
 
+test_that("Observation labels returned by clustering.CBASS have correct length (=NROW(X))", {
+  cbass_fit <- CBASS(presidential_speech)
 
+  # Percent
+  expect_equal(NROW(presidential_speech),
+               length(clustering(cbass_fit, percent = 0.2)$clustering.assignment.obs))
+
+  # k.obs
+  expect_equal(NROW(presidential_speech),
+               length(clustering(cbass_fit, k.obs = 10)$clustering.assignment.obs))
+
+  # k.var
+  expect_equal(NROW(presidential_speech),
+               length(clustering(cbass_fit, k.var = 10)$clustering.assignment.obs))
+})
+
+test_that("Variable labels returned by clustering.CBASS have correct length (=NCOL(X))", {
+  cbass_fit <- CBASS(presidential_speech)
+
+  # Percent
+  expect_equal(NCOL(presidential_speech),
+               length(clustering(cbass_fit, percent = 0.2)$clustering.assignment.var))
+
+  # k.obs
+  expect_equal(NCOL(presidential_speech),
+               length(clustering(cbass_fit, k.obs = 10)$clustering.assignment.var))
+
+  # k.var
+  expect_equal(NCOL(presidential_speech),
+               length(clustering(cbass_fit, k.var = 10)$clustering.assignment.var))
+
+})
+
+test_that("Clustered data matrix returned by clustering.CBASS has correct dimensions (=dim(X))",{
+  cbass_fit <- CBASS(presidential_speech)
+
+  # Percent
+  expect_equal(dim(presidential_speech),
+               dim(clustering(cbass_fit, percent = .2)$cluster.mean.matrix))
+
+  # k.obs
+  expect_equal(dim(presidential_speech),
+               dim(clustering(cbass_fit, k.obs = 10)$cluster.mean.matrix))
+
+  # k.var
+  expect_equal(dim(presidential_speech),
+               dim(clustering(cbass_fit, k.var = 10)$cluster.mean.matrix))
+})
 
 
 # context('CBASS Saving')

--- a/tests/testthat/testCBASS.R
+++ b/tests/testthat/testCBASS.R
@@ -14,6 +14,9 @@ test_that("CBASS Runs",{
     NA
   )
 })
+test_that("CBASS Runs w/ X.center.global=FALSE",{
+  expect_error(CBASS(presidential_speech, X.center.global = FALSE), regexp = NA)
+})
 test_that("CBASS Runs w/ cbassviz",{
   expect_error(
     cbass.fit <- CBASS(X=Xdat,control = list(alg.type='cbassviz')),
@@ -172,6 +175,41 @@ test_that("Clustered data matrix returned by clustering.CBASS has correct dimens
                dim(clustering(cbass_fit, k.var = 10)$cluster.mean.matrix))
 })
 
+test_that("CBASS clustering (w/ X.center.global == TRUE) returns zero matrix at full regularization", {
+  cbass_fit <- CBASS(presidential_speech, X.center.global = TRUE)
+  expect_equal(clustering(cbass_fit, percent = 1)$cluster.mean.matrix,
+               0 * presidential_speech)
+})
+
+test_that("CBASS clustering (w/ X.center.global == FALSE) returns global mean at full regularization", {
+  cbass_fit <- CBASS(presidential_speech, X.center.global = FALSE)
+  expect_equal(clustering(cbass_fit, percent = 1)$cluster.mean.matrix,
+               0 * presidential_speech + mean(presidential_speech))
+})
+
+test_that("CBASS clustering (w/ X.center.global == TRUE) returns (centered) original data at 0 regularization", {
+  cbass_fit <- CBASS(presidential_speech, X.center.global = TRUE)
+  expect_equal(clustering(cbass_fit, percent = 0)$cluster.mean.matrix,
+               presidential_speech - mean(presidential_speech))
+})
+
+test_that("CBASS clustering (w/ X.center.global == FALSE) returns original data at 0 regularization", {
+  cbass_fit <- CBASS(presidential_speech, X.center.global = FALSE)
+  expect_equal(clustering(cbass_fit, percent = 0)$cluster.mean.matrix,
+               presidential_speech)
+})
+
+test_that("CBASS clustering cluster.mean.matrix respects obsveration/row labels", {
+  cbass_fit <- CBASS(presidential_speech)
+  expect_equal(rownames(presidential_speech),
+               rownames(clustering(cbass_fit, percent = .3)$cluster.mean.matrix))
+})
+
+test_that("CBASS clustering cluster.mean.matrix respects variable/column labels",{
+  cbass_fit <- CBASS(presidential_speech)
+  expect_equal(colnames(presidential_speech),
+               colnames(clustering(cbass_fit, percent = .3)$cluster.mean.matrix))
+})
 
 # context('CBASS Saving')
 # test_that("saveviz runs with static obs.dend, k.obs",{

--- a/vignettes/QuickStart.Rmd
+++ b/vignettes/QuickStart.Rmd
@@ -253,7 +253,7 @@ table(cbass.clusters$clustering.assignment.obs)
 # variable clusters
 table(cbass.clusters$clustering.assignment.var)
 # mean matrix
-cbass.clusters$cluster.mean.matrix[,1:5]
+cbass.clusters$cluster.mean.matrix[1:5,]
 ```
 
 


### PR DESCRIPTION
Changed code to make clustering mean matrix returned by clustering.CBASS have same dimensions as input. Also added a basic test related to this, and (hopefully?) made row/column/variable/observation-related names more readable.