### PR TITLE
Rename branches on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ deploy:
   skip_cleanup: true
   github_token: $GITHUB_TOKEN
   on:
-    branch: master
+    branch: develop
   local_dir: .
-  target_branch: stable
+  target_branch: master
   condition: $TRAVIS_OS_NAME = "linux"


### PR DESCRIPTION
Rename branches in Travis build script to work around the fact GH can only serve GH pages from the `master` branch