### PR TITLE
Micro-Optimizations

### DIFF
--- a/R/carp.R
+++ b/R/carp.R
@@ -232,11 +232,11 @@ CARP <- function(X,
   weight_vec <- weight_mat_to_vec(weight_matrix)
 
   if (verbose.basic) message("Pre-computing weight-based edge sets")
-  PreCompList <- suppressMessages(ConvexClusteringPreCompute(
-    X = X,
-    weights = weight_vec,
-    rho = rho
-  ))
+  PreCompList <- ConvexClusteringPreCompute(X = X,
+                                            weights = weight_vec,
+                                            rho = rho,
+                                            verbose = verbose.deep)
+
   cardE <- NROW(PreCompList$E)
 
   if (verbose.basic) message("Computing CARP Path")

--- a/R/cbass.R
+++ b/R/cbass.R
@@ -295,22 +295,17 @@ CBASS <- function(X,
   row_weights <- row_weights / (sum(row_weights) * sqrt(n.obs))
   col_weights <- col_weights / (sum(col_weights) * sqrt(p.var))
 
-  PreCompList.row <- suppressMessages(
-    ConvexClusteringPreCompute(
-      X = t(X),
-      weights = row_weights,
-      rho = rho
-    )
-  )
+  PreCompList.row <- ConvexClusteringPreCompute(X = t(X),
+                                                weights = row_weights,
+                                                rho = rho,
+                                                verbose = verbose.deep)
   cardE.row <- NROW(PreCompList.row$E)
 
-  PreCompList.col <- suppressMessages(
-    ConvexClusteringPreCompute(
-      X = X,
-      weights = col_weights,
-      rho = rho
-    )
-  )
+  PreCompList.col <- ConvexClusteringPreCompute(X = X,
+                                                weights = col_weights,
+                                                rho = rho,
+                                                verbose = verbose.deep)
+
   cardE.col <- NROW(PreCompList.col$E)
 
   if (verbose.basic) message("Computing CBASS Path")

--- a/R/utils.R
+++ b/R/utils.R
@@ -285,7 +285,6 @@ ISP <- function(sp.path, v.path, u.path, lambda.path, cardE) {
       unname() -> lambda.path.inter2
   }
 
-  seq2 <- Vectorize(seq.default, vectorize.args = c("from", "to"))
   if (nrow(mc.frame) == 0) {
     dplyr::tibble(
       Iter = 1:ncol(u.path)
@@ -324,8 +323,7 @@ ISP <- function(sp.path, v.path, u.path, lambda.path, cardE) {
             NewU = purrr::map2(.x = Iter, .y = data, .f = function(x, y) {
               cur.u <- u.path[, x]
               next.u <- u.path[, x + 1]
-              new.u <- matrix(seq2(from = cur.u, to = next.u, length.out = nrow(y) + 1), nrow = length(cur.u), byrow = TRUE)
-              new.u <- new.u[, -ncol(new.u)]
+              new.u <- tcrossprod((next.u - cur.u) / NROW(y), seq(0, NROW(y) - 1)) + cur.u
               lapply(seq_len(ncol(new.u)), function(i) {
                 new.u[, i]
               })


### PR DESCRIPTION
This PR contains two commits which speed up pre- and post-processing. The net effect of the two changes is to bring `CARP(presidential_speech)` down to about 0.9s and `CBASS(presidential_speech)` to 1.4s. 

I will copy the descriptions from the original PR that proposed them (#22), updating a few references:

----- 

1c6d7f9 makes two minor speed-ups to pre-processing:

    Avoid Reduce(, lapply(...)) in favor of outer
    (which is fully vectorized) to construct edge
    incidence matrices
    Construct Vmat directly rather than in a loop

I'm not sure what these functions are exactly supposed to be calculating, this change passes the `all.equal` test on the following (and save about a second on total time).

```
list(
  CARPVIZ   = CARP(presidential_speech, alg.type="carpviz"), 
  CARP1.2   = CARP(presidential_speech, alg.type="carp", t=1.2), 
  CARP1.1   = CARP(presidential_speech, alg.type="carp", t=1.1), 
  CARP1.05  = CARP(presidential_speech, alg.type="carp", t=1.05), 
  CBASSVIZ  = CBASS(presidential_speech, alg.type="cbassviz"), 
  CBASS1.2  = CBASS(presidential_speech, alg.type="cbass", t=1.2), 
  CBASS1.1  = CBASS(presidential_speech, alg.type="cbass", t=1.1), 
  CBASS1.05 = CBASS(presidential_speech, alg.type="cbass", t=1.05)
)
```

Tangentially related: Running `profvis` on the above, it looks like the last obvious bottle-neck is ISP, which takes 6690ms out of 9970ms (or about 67% of total run time) on the above. (Results from a single benchmark, so might not be robust). In particular, most of that time (~4900ms) is in one step [1]. I'll take a look and see if it can be improved, but on first glance I can't really tell what it's doing.

[1] https://github.com/DataSlingers/clustRviz/blob/master/R/utils.R#L350-L357

---

f7ecb35 speeds up ISP with a one line tweak. After this test, the 8 runs about take about 7 seconds, with the total time spent in ISP being reduced to about 2010ms.

As a result, `CARP(presidential_speech)` now takes about 0.9s while `CBASS(presidential_speech)` is taking about 1.5s.

As before, the `all.equal` test on 8 different versions runs on `presidential_speech` passes (gets the same result as `develop`.)