### PR TITLE
update gganimate api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ sudo: false
 cache: packages
 warnings_are_errors: true
 
+## Necessary for gifski dependency
+addons:
+  apt:
+    packages:
+      - cargo
+
 before_install:
   - gcc --version
   - g++ --version

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,19 +4,19 @@ Title: Convex (Bi)Clustering via Algorithmic Regularization Paths
 Version: 0.1.0
 Authors@R: c(
   person("John", "Nagorski", role = c("aut", "cre"), email = "jn13@rice.edu"),
-  person("Michael", "Weylandt", role = "ctb", email = "Michael.Weylandt@rice.edu"),
-  person("Genevera", "Allen", role = "ths", email = "gallen@rice.edu"),
-  person("Galili", "Tal", role="cph", comment = "R/util_rect_dendrogram.R"),
-  person("Warnes", "Gregory", role="cph", comment = "R/util_myheatmap2.R"),
-  person("Lewis", "Brian W.", role="cph", comment = "R/util_hcs.R"),
-  person("R Core Team", role="cph", comment = "R/util_myrecthclust.R"))
+  person("Michael", "Weylandt", role = "aut", email = "Michael.Weylandt@rice.edu"),
+  person("Genevera", "Allen", role = c("ths", "aut"), email = "gallen@rice.edu"),
+  person("Galili", "Tal", role = "cph", comment = "R/util_rect_dendrogram.R"),
+  person("Warnes", "Gregory", role = "cph", comment = "R/util_myheatmap2.R"),
+  person("Lewis", "Brian W.", role = "cph", comment = "R/util_hcs.R"),
+  person("R Core Team", role = "cph", comment = "R/util_myrecthclust.R"))
 Description: Provides interactive graphics and fast computation for the Convex Clustering problem.
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Depends: R (>= 2.10)
 Remotes:
-    thomasp85/gganimate@v0.1.1
+    thomasp85/gganimate
 Imports:
     RcppEigen,
     Rcpp, 
@@ -36,7 +36,7 @@ Imports:
     gtools,
     ggrepel,
     RColorBrewer,
-    gganimate
+    gganimate (>= 0.1.1)
 RoxygenNote: 6.1.0
 LinkingTo: Rcpp, RcppEigen
 Suggests: testthat,

--- a/R/plot_carp.R
+++ b/R/plot_carp.R
@@ -541,6 +541,10 @@ carp_dendro_plot <- function(x,
         crv_error(sQuote("percent"), " must be a scalar between 0 and 1 (inclusive).")
       }
 
+      if(percent == 0){ ## Don't bother showing boxes if percent is 0 and bail early
+        return(invisible(x))
+      }
+
       k <- x$carp.cluster.path.vis %>% filter(.data$LambdaPercent <= percent) %>%
                                        select(.data$NCluster) %>%
                                        summarize(NCluster = min(.data$NCluster)) %>%

--- a/R/plot_cbass.R
+++ b/R/plot_cbass.R
@@ -456,7 +456,9 @@ cbass_heatmap_plot <- function(x,
                                k.obs,
                                k.var,
                                heatrow.label.cex,
-                               heatcol.label.cex){
+                               heatcol.label.cex,
+                               breaks = NULL,
+                               heatmap_col = NULL){
 
   dots <- list(...)
 
@@ -493,12 +495,17 @@ cbass_heatmap_plot <- function(x,
     crv_error(sQuote("heatcol.label.cex"), " must be positive.")
   }
 
-  nbreaks <- 50
-  quant.probs <- seq(0, 1, length.out = nbreaks)
-  breaks <- unique(quantile(as.vector(U), probs = quant.probs))
-  nbreaks <- length(breaks)
+  if (is.null(breaks)) {
+    nbreaks <- 50
+    quant.probs <- seq(0, 1, length.out = nbreaks)
+    breaks <- unique(quantile(as.vector(U), probs = quant.probs))
+  }
 
-  heatcols <- colorRampPalette(c("blue", "yellow"))(nbreaks - 1)
+  if (is.null(heatmap_col)) {
+    nbreaks <- length(breaks)
+    heatmap_col <- colorRampPalette(c("blue", "yellow"))(nbreaks - 1)
+  }
+
   my.cols  <- adjustcolor(c("black", "grey"), alpha.f = .3)
 
   my.heatmap.2(
@@ -510,7 +517,7 @@ cbass_heatmap_plot <- function(x,
     density.info = "none",
     key = FALSE,
     breaks = breaks,
-    col = heatcols,
+    col = heatmap_col,
     symkey = FALSE,
     Row.hclust = as.hclust(x$cbass.dend.obs),
     Col.hclust = as.hclust(x$cbass.dend.var),

--- a/R/save.R
+++ b/R/save.R
@@ -23,7 +23,7 @@ saveviz <- function(x, ...) {
 #' @importFrom dplyr filter select distinct rename mutate left_join select %>%
 #' @importFrom tools file_ext file_path_sans_ext
 #' @importFrom grDevices adjustcolor png dev.off dev.cur dev.set
-#' @importFrom gganimate gganimate
+#' @importFrom gganimate transition_manual anim_save
 #' @importFrom animation ani.options saveGIF
 #' @importFrom RColorBrewer brewer.pal
 #' @rdname plot_carp
@@ -131,7 +131,8 @@ saveviz.CARP <- function(x,
 
       dplyr::bind_rows(plot.frame.list) -> plot.frame.ani
       plot.frame.ani %>%
-        ggplot2::ggplot(ggplot2::aes(x = V1, y = V2, group = Obs, frame = PlotIdx)) +
+        ggplot2::ggplot(ggplot2::aes(x = V1, y = V2, group = Obs)) +
+        gganimate::transition_manual(PlotIdx) +
         ggplot2::geom_path(
           ggplot2::aes(x = V1, y = V2),
           linejoin = "round",
@@ -154,7 +155,7 @@ saveviz.CARP <- function(x,
         ggplot2::ylab(axis[2]) -> p
       animation::ani.options(ani.width  = convert_units(width,  from = units, to = "px"),
                              ani.height = convert_units(height, from = units, to = "px"))
-      gganimate::gganimate(p, file.name)
+      gganimate::anim_save(filename = file.name,animation = p)
     },
     dendrogram = {
       cur.file.ext <- tools::file_ext(file.name)
@@ -212,7 +213,6 @@ saveviz.CARP <- function(x,
 #' @importFrom dplyr tibble filter select distinct rename mutate left_join select_ %>%
 #' @importFrom tools file_ext file_path_sans_ext
 #' @importFrom grDevices adjustcolor png colorRampPalette dev.off dev.cur dev.set
-#' @importFrom gganimate gganimate
 #' @importFrom animation ani.options saveGIF
 #' @importFrom RColorBrewer brewer.pal
 #' @rdname plot_cbass

--- a/R/save.R
+++ b/R/save.R
@@ -6,13 +6,14 @@ saveviz <- function(x, ...) {
 
 #' @param file.name The name of the output file. The type of resulting image
 #'                  is determined from the extension.
-#' @param image.type The type of image output. If \code{image.type == "static"},
-#'                   a fixed visualization of a single solution, with the level
-#'                   of regularization being determined by \code{percent} and
-#'                   \code{k}. If \code{image.type == "dynamic"}, an animated
-#'                   visualization which varies along the solution path.
+#' @param dynamic Should the resulting animation be dynamic (animated) or not?
+#'                If \code{TRUE}, a dynamic visualization which varies along the
+#'                \code{CARP} solution path at a grid given by \code{percent.seq}
+#'                is produced (as a \code{GIF}). If \code{FALSE}, a fixed visualization
+#'                at a single solution (determined by either \code{percent} or \code{k}
+#'                if supplied) is produced.
 #' @param percent.seq A grid of values of \code{percent} along which to generate
-#'                    dynamic visualizations (if \code{image.type == "dynamic"})
+#'                    dynamic visualizations (if \code{dynamic == TRUE})
 #' @param width The width of the output, given in \code{unit}s
 #' @param height The height of the output, given in \code{unit}s
 #' @param units The unit in which \code{width} and \code{height} are specified
@@ -31,7 +32,7 @@ saveviz <- function(x, ...) {
 saveviz.CARP <- function(x,
                          file.name,
                          type = c("dendrogram", "path"),
-                         image.type = c("dynamic", "static"),
+                         dynamic = TRUE,
                          axis = c("PC1", "PC2"),
                          dend.branch.width = 2,
                          dend.labels.cex = .6,
@@ -55,13 +56,16 @@ saveviz.CARP <- function(x,
   NCluster <- NULL
 
   type       <- match.arg(type)
-  image.type <- match.arg(image.type)
+
+  if (!is_logical_scalar(dynamic)) {
+    crv_error(sQuote("dynamic"), " must be either TRUE or FALSE.")
+  }
 
   if (!all(vapply(percent.seq, is_percent_scalar, TRUE))) {
     crv_error("All elements of ", sQuote("percent.seq"), " must be between 0 and 1.")
   }
 
-  if(image.type == "static"){
+  if (!dynamic) {
     dev_cur <- dev.cur()
     on.exit(dev.set(dev_cur))
     switch(type,
@@ -177,13 +181,14 @@ saveviz.CARP <- function(x,
 
 #' @param file.name The name of the output file. The type of resulting image
 #'                  is determined from the extension.
-#' @param image.type The type of image output. If \code{image.type == "static"},
-#'                   a fixed visualization of a single solution, with the level
-#'                   of regularization being determined by \code{percent} and
-#'                   \code{k}. If \code{image.type == "dynamic"}, an animated
-#'                   visualization which varies along the solution path.
+#' @param dynamic Should the resulting animation be dynamic (animated) or not?
+#'                If \code{TRUE}, a dynamic visualization which varies along the
+#'                \code{CARP} solution path at a grid given by \code{percent.seq}
+#'                is produced (as a \code{GIF}). If \code{FALSE}, a fixed visualization
+#'                at a single solution (determined by \code{percent}, \code{k.obs} or
+#'                \code{k.var} if supplied) is produced.
 #' @param percent.seq A grid of values of \code{percent} along which to generate
-#'                    dynamic visualizations (if \code{image.type == "dynamic"})
+#'                    dynamic visualizations (if \code{dynamic == TRUE})
 #' @param width The width of the output, given in \code{unit}s
 #' @param height The height of the output, given in \code{unit}s
 #' @param units The unit in which \code{width} and \code{height} are specified
@@ -197,7 +202,7 @@ saveviz.CARP <- function(x,
 saveviz.CBASS <- function(x,
                           file.name,
                           type = c("heatmap", "obs.dendrogram", "var.dendrogram"),
-                          image.type = c("dynamic", "static"),
+                          dynamic = TRUE,
                           dend.branch.width = 2,
                           dend.labels.cex = .6,
                           heatrow.label.cex = 1.5,
@@ -212,13 +217,16 @@ saveviz.CBASS <- function(x,
                           ...) {
 
   type       <- match.arg(type)
-  image.type <- match.arg(image.type)
+
+  if (!is_logical_scalar(dynamic)) {
+    crv_error(sQuote("dynamic"), " must be either TRUE or FALSE.")
+  }
 
   if (!all(vapply(percent.seq, is_percent_scalar, TRUE))) {
     crv_error("All elements of ", sQuote("percent.seq"), " must be between 0 and 1.")
   }
 
-  if(image.type == "static"){
+  if (!dynamic) {
     dev_cur <- dev.cur()
     on.exit(dev.set(dev_cur))
     switch(type,

--- a/R/save.R
+++ b/R/save.R
@@ -81,6 +81,9 @@ saveviz.CARP <- function(x,
     return(invisible(file.name))
   }
 
+  ## From here, we can safely assume we are making a dynamic plot (i.e., a GIF)
+  file.name <- ensure_gif(file.name)
+
   switch(
     type,
     path = {
@@ -111,14 +114,6 @@ saveviz.CARP <- function(x,
         ) -> plot.frame
       plot.frame.list <- list()
 
-      cur.file.ext <- tools::file_ext(file.name)
-      if (cur.file.ext != "gif") {
-        file.name <- paste(
-          tools::file_path_sans_ext(file.name),
-          "gif",
-          sep = "."
-        )
-      }
       for (seq.idx in seq_along(percent.seq)) {
         percent <- percent.seq[seq.idx]
         plot.frame %>%
@@ -158,14 +153,6 @@ saveviz.CARP <- function(x,
       gganimate::anim_save(filename = file.name,animation = p)
     },
     dendrogram = {
-      cur.file.ext <- tools::file_ext(file.name)
-      if (cur.file.ext != "gif") {
-        file.name <- paste(
-          tools::file_path_sans_ext(file.name),
-          "gif",
-          sep = "."
-        )
-      }
       animation::saveGIF({
         for (seq.idx in seq_along(percent.seq)) {
           percent <- percent.seq[seq.idx]
@@ -295,18 +282,13 @@ saveviz.CBASS <- function(x,
     return(invisible(file.name))
   }
 
+  ## From here, we can safely assume we are making a dynamic plot (i.e., a GIF)
+  file.name <- ensure_gif(file.name)
+
   switch(
     type,
     heatmap = {
       ### Dynamic Heatmap
-      cur.file.ext <- tools::file_ext(file.name)
-      if (cur.file.ext != "gif") {
-        file.name <- paste(
-          tools::file_path_sans_ext(file.name),
-          "gif",
-          sep = "."
-        )
-      }
       if (x$X.center.global) {
         X.heat <- x$X
         X.heat <- X.heat - mean(X.heat)
@@ -387,14 +369,6 @@ saveviz.CBASS <- function(x,
     },
     obs.dendrogram = {
       ### Dynamic Obs Dend
-      cur.file.ext <- tools::file_ext(file.name)
-      if (cur.file.ext != "gif") {
-        file.name <- paste(
-          tools::file_path_sans_ext(file.name),
-          "gif",
-          sep = "."
-        )
-      }
       lam.vec <- x$cbass.sol.path$lambda.path %>% as.vector()
       max.lam <- max(lam.vec)
       lam.vec %>%
@@ -448,14 +422,6 @@ saveviz.CBASS <- function(x,
     },
     var.dendrogram = {
       ### Dynamic Var Dend
-      cur.file.ext <- tools::file_ext(file.name)
-      if (cur.file.ext != "gif") {
-        file.name <- paste(
-          tools::file_path_sans_ext(file.name),
-          "gif",
-          sep = "."
-        )
-      }
       lam.vec <- x$cbass.sol.path$lambda.path %>% as.vector()
       max.lam <- max(lam.vec)
       lam.vec %>%

--- a/R/saveviz_helpers.R
+++ b/R/saveviz_helpers.R
@@ -66,3 +66,20 @@ crv_new_dev_static <- function(file.name, width, height, units = c("in", "cm", "
 
   dev_func(file.name, width = width, height = height)
 }
+
+#' Convert a file name to ".gif" and warn if necessary
+#' @noRd
+#' @importFrom tools file_ext file_path_sans_ext
+ensure_gif <- function(file_name){
+
+  current_extension <- file_ext(file_name)
+
+  if (current_extension != "gif") {
+    new_file_name <- paste(file_path_sans_ext(file_name), ".gif", sep = "")
+    crv_warning("File extension for dynamic visualization is not ", sQuote(".gif"),
+                " -- changing from ", sQuote(file_name), " to ", sQuote(new_file_name))
+    new_file_name
+  } else {
+    file_name
+  }
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repo
 
 # clustRviz
 
-`clustRviz` aims to enable fast computation and easy visualization of Convex Clustering 
+`clustRviz` aims to enable fast computation and easy visualization of Convex Clustering
 solution paths.
 
 ## Installation
@@ -35,28 +35,73 @@ devtools::install_github("DataSlingers/clustRviz")
 ```
 
 Note that `RcppEigen` (which `clustRviz` internally) triggers many compiler warnings
-(which cannot be suppressed per [CRAN policies](http://cran.r-project.org/web/packages/policies.html#Source-packages)).
+(which cannot be suppressed per
+[CRAN policies](http://cran.r-project.org/web/packages/policies.html#Source-packages)).
 Many of these warnings can be locally suppressed by adding the line `CXX11FLAGS+=-Wno-ignored-attributes`
 to your `~/.R/Makevars` file.
 
-## Example
+`clustRviz` also depends on the development version of the `gganimate` package,
+which is not yet on CRAN, but may be found [here](https://github.com/thomasp85/gganimate).
 
-Here is a quick example 
-```{r example}
+## Quick-Start
+
+There are two main entry points to the `clustRviz` package, the `CARP` and `CBASS`
+functions, which perform convex clustering and convex biclustering respectively.
+We demonstrate the use of these two functions on a text minining data set,
+`presidential_speech`, which measures how often the 44 U.S. presidents used certain
+words in their public addresses.
+
+```{r load_data}
 library(clustRviz)
-carp_fit <- CARP(presidential_speech)
-carp_fit
+data(presidential_speech)
+presidential_speech[1:6, 1:6]
 ```
 
-```{r plot, include=FALSE, results="hide"}
+We begin by clustering this data set, grouping the rows (presidents) into clusters:
+
+```{r carp_example}
+carp_fit <- CARP(presidential_speech)
+print(carp_fit)
+```
+
+The algorithmic regularization technique employed by `CARP` makes computation of
+the whole solution path almost immediate.
+
+We can examine the result of `CARP` graphically. We begin with a standard dendrogram,
+with three clusters highlighted:
+
+```{r carp_dendro}
+plot(carp_fit, type = "dendrogram", k = 3)
+```
+
+Examing the dendrogram, we see two clear clusters, consisting of pre-WWII and post-WWII
+presidents and Warren G. Harding as a possible outlier. Harding is generally considered
+one of the worst US presidents of all time, so this is perhaps not too surprising.
+
+A more interesting visualization is the dynamic path visualization, whereby we can
+watch the clusters fuse as the regularization level is increased:
+
+```{r carp_dynamic, eval = FALSE}
+plot(carp_fit, type = "dynamic_path")
+```
+
+```{r carp_dynamic_impl, echo = FALSE, results = "hide", message=FALSE}
 if (!dir.exists("inst")) {
   dir.create("inst")
 }
 
-saveviz(carp_fit, 
-        file.name  = "inst/path_dyn.gif",
-        type       = "path",
-        image.type = "dynamic")
+saveviz(carp_fit, file.name = "inst/path_dyn.gif", type = "path", dynamic = TRUE)
 ```
 
-<img src="./inst/path_dyn.gif" width="70%">
+<img src="./inst/path_dyn.gif" width = "70%">
+
+The use of `CBASS` for convex biclustering is similar, and we demonstrate it here
+with a cluster heatmap, with the regularization set to give 3 observation clusters:
+
+```{r cbass}
+cbass_fit <- CBASS(presidential_speech)
+plot(cbass_fit, k.obs = 3)
+```
+
+More details about the use and mathematical formulation of `CARP` and `CBASS`
+may be found in the package documentation.

--- a/tests/testthat/test_carp_plot_save.R
+++ b/tests/testthat/test_carp_plot_save.R
@@ -6,14 +6,14 @@ test_that("saveviz.CARP can save a dynamic path", {
   skip("Need to rework dynamic visualizations")
 
   carp_fit <- CARP(presidential_speech)
-  expect_no_error(saveviz(carp_fit, file.name = tempfile(), plot.type = "path", image.type = "dynamic"))
+  expect_no_error(saveviz(carp_fit, file.name = tempfile(), plot.type = "path", dynamic = TRUE))
 })
 
 test_that("saveviz.CARP can save a dynamic dendrogram", {
   skip("Need to rework dynamic visualizations")
 
   carp_fit <- CARP(presidential_speech)
-  expect_no_error(saveviz(carp_fit, file.name = tempfile(), plot.type = "dendrogram", image.type = "dynamic"))
+  expect_no_error(saveviz(carp_fit, file.name = tempfile(), plot.type = "dendrogram", dynamic = TRUE))
 })
 
 
@@ -22,7 +22,7 @@ test_that("saveviz.CARP can save a static path as a PNG", {
 
   carp_fit <- CARP(presidential_speech)
   temp_file <- file.path(tempdir(), "tester.png")
-  expect_equal(invisible(temp_file), saveviz(carp_fit, file.name = temp_file, type = "path", image.type = "static"))
+  expect_equal(invisible(temp_file), saveviz(carp_fit, file.name = temp_file, type = "path", dynamic = FALSE))
   expect_true(file.exists(temp_file))
 })
 
@@ -31,7 +31,7 @@ test_that("saveviz.CARP can save a static dendrogram as a JPG", {
 
   carp_fit <- CARP(presidential_speech)
   temp_file <- file.path(tempdir(), "tester.jpg")
-  expect_equal(invisible(temp_file), saveviz(carp_fit, file.name = temp_file, type = "dendrogram", image.type = "static"))
+  expect_equal(invisible(temp_file), saveviz(carp_fit, file.name = temp_file, type = "dendrogram", dynamic = FALSE))
   expect_true(file.exists(temp_file))
 })
 
@@ -40,7 +40,7 @@ test_that("saveviz.CARP can save a dynamic dendrogram as a GIF", {
 
   carp_fit <- CARP(presidential_speech)
   temp_file <- file.path(tempdir(), "tester.gif")
-  expect_no_warning(sv_res <- saveviz(carp_fit, file.name = temp_file, type = "dendrogram", image.type = "dynamic"))
+  expect_no_warning(sv_res <- saveviz(carp_fit, file.name = temp_file, type = "dendrogram", dynamic = TRUE))
   expect_equal(sv_res, invisible(temp_file))
   expect_true(file.exists(temp_file))
 })

--- a/tests/testthat/test_carp_plot_save.R
+++ b/tests/testthat/test_carp_plot_save.R
@@ -34,3 +34,13 @@ test_that("saveviz.CARP can save a static dendrogram as a JPG", {
   expect_equal(invisible(temp_file), saveviz(carp_fit, file.name = temp_file, type = "dendrogram", image.type = "static"))
   expect_true(file.exists(temp_file))
 })
+
+test_that("saveviz.CARP can save a dynamic dendrogram as a GIF", {
+  skip_on_cran()
+
+  carp_fit <- CARP(presidential_speech)
+  temp_file <- file.path(tempdir(), "tester.gif")
+  expect_no_warning(sv_res <- saveviz(carp_fit, file.name = temp_file, type = "dendrogram", image.type = "dynamic"))
+  expect_equal(sv_res, invisible(temp_file))
+  expect_true(file.exists(temp_file))
+})

--- a/tests/testthat/test_carp_plot_save.R
+++ b/tests/testthat/test_carp_plot_save.R
@@ -2,21 +2,6 @@ context("Test saveviz.CARP")
 
 ## FIXME - Make these rigorous tests: right now, we're just checking for no errors on the default path
 
-test_that("saveviz.CARP can save a dynamic path", {
-  skip("Need to rework dynamic visualizations")
-
-  carp_fit <- CARP(presidential_speech)
-  expect_no_error(saveviz(carp_fit, file.name = tempfile(), plot.type = "path", dynamic = TRUE))
-})
-
-test_that("saveviz.CARP can save a dynamic dendrogram", {
-  skip("Need to rework dynamic visualizations")
-
-  carp_fit <- CARP(presidential_speech)
-  expect_no_error(saveviz(carp_fit, file.name = tempfile(), plot.type = "dendrogram", dynamic = TRUE))
-})
-
-
 test_that("saveviz.CARP can save a static path as a PNG", {
   skip_on_cran()
 
@@ -41,6 +26,16 @@ test_that("saveviz.CARP can save a dynamic dendrogram as a GIF", {
   carp_fit <- CARP(presidential_speech)
   temp_file <- file.path(tempdir(), "tester.gif")
   expect_no_warning(sv_res <- saveviz(carp_fit, file.name = temp_file, type = "dendrogram", dynamic = TRUE))
+  expect_equal(sv_res, invisible(temp_file))
+  expect_true(file.exists(temp_file))
+})
+
+test_that("saveviz.CARP can save a dynamic path as a GIF", {
+  skip_on_cran()
+
+  carp_fit <- CARP(presidential_speech)
+  temp_file <- file.path(tempdir(), "tester.gif")
+  expect_no_warning(sv_res <- saveviz(carp_fit, file.name = temp_file, type = "path", dynamic = TRUE))
   expect_equal(sv_res, invisible(temp_file))
   expect_true(file.exists(temp_file))
 })

--- a/tests/testthat/test_cbass_plot_save.R
+++ b/tests/testthat/test_cbass_plot_save.R
@@ -6,28 +6,28 @@ test_that("saveviz.CBASS can save a dynamic heatmap", {
   skip("Need to rework dynamic visualizations")
 
   cbass_fit <- CBASS(presidential_speech)
-  expect_no_error(saveviz(cbass_fit, file.name = tempfile(), plot.type = "heatmap", image.type = "dynamic"))
+  expect_no_error(saveviz(cbass_fit, file.name = tempfile(), plot.type = "heatmap", dynamic = TRUE))
 })
 
 test_that("saveviz.CBASS can save a dynamic observation dendrogram", {
   skip("Need to rework dynamic visualizations")
 
   cbass_fit <- CBASS(presidential_speech)
-  expect_no_error(saveviz(cbass_fit, file.name = tempfile(), plot.type = "obs.dendrogram", image.type = "dynamic"))
+  expect_no_error(saveviz(cbass_fit, file.name = tempfile(), plot.type = "obs.dendrogram", dynamic = TRUE))
 })
 
 test_that("saveviz.CBASS can save a dynamic variable dendrogram", {
   skip("Need to rework dynamic visualizations")
 
   cbass_fit <- CBASS(presidential_speech)
-  expect_no_error(saveviz(cbass_fit, file.name = tempfile(), plot.type = "var.dendrogram", image.type = "dynamic"))
+  expect_no_error(saveviz(cbass_fit, file.name = tempfile(), plot.type = "var.dendrogram", dynamic = TRUE))
 })
 test_that("saveviz.CBASS can save a static heatmap as a PNG", {
   skip_on_cran()
 
   cbass_fit <- CBASS(presidential_speech)
   temp_file <- file.path(tempdir(), "tester.png")
-  expect_equal(invisible(temp_file), saveviz(cbass_fit, file.name = temp_file, type = "heatmap", image.type = "static"))
+  expect_equal(invisible(temp_file), saveviz(cbass_fit, file.name = temp_file, type = "heatmap", dynamic = FALSE))
   expect_true(file.exists(temp_file))
 })
 
@@ -36,7 +36,7 @@ test_that("saveviz.CBASS can save a static observation dendrogram as a JPG", {
 
   cbass_fit <- CBASS(presidential_speech)
   temp_file <- file.path(tempdir(), "tester.jpg")
-  expect_equal(invisible(temp_file), saveviz(cbass_fit, file.name = temp_file, type = "obs.dendrogram", image.type = "static"))
+  expect_equal(invisible(temp_file), saveviz(cbass_fit, file.name = temp_file, type = "obs.dendrogram", dynamic = FALSE))
   expect_true(file.exists(temp_file))
 })
 
@@ -46,7 +46,7 @@ test_that("saveviz.CBASS can save a static variable dendrogram as a PDF", {
 
   cbass_fit <- CBASS(presidential_speech)
   temp_file <- file.path(tempdir(), "tester.pdf")
-  expect_equal(invisible(temp_file), saveviz(cbass_fit, file.name = temp_file, type = "var.dendrogram", image.type = "static"))
+  expect_equal(invisible(temp_file), saveviz(cbass_fit, file.name = temp_file, type = "var.dendrogram", dynamic = FALSE))
   expect_true(file.exists(temp_file))
 })
 
@@ -55,7 +55,7 @@ test_that("saveviz.CBASS can save a dynamic observation dendrogram as a GIF", {
 
   cbass_fit <- CBASS(presidential_speech)
   temp_file <- file.path(tempdir(), "tester.gif")
-  expect_no_warning(sv_res <- saveviz(cbass_fit, file.name = temp_file, type = "obs.dendrogram", image.type = "dynamic"))
+  expect_no_warning(sv_res <- saveviz(cbass_fit, file.name = temp_file, type = "obs.dendrogram", dynamic = TRUE))
   expect_equal(sv_res, invisible(temp_file))
   expect_true(file.exists(temp_file))
 })
@@ -65,18 +65,17 @@ test_that("saveviz.CBASS can save a dynamic variable dendrogram as a GIF", {
 
   cbass_fit <- CBASS(presidential_speech)
   temp_file <- file.path(tempdir(), "tester.gif")
-  expect_no_warning(sv_res <- saveviz(cbass_fit, file.name = temp_file, type = "var.dendrogram", image.type = "dynamic"))
+  expect_no_warning(sv_res <- saveviz(cbass_fit, file.name = temp_file, type = "var.dendrogram", dynamic = TRUE))
   expect_equal(sv_res, invisible(temp_file))
   expect_true(file.exists(temp_file))
 })
-
 
 test_that("saveviz.CBASS can save a dynamic heatmap as a GIF", {
   skip_on_cran()
 
   cbass_fit <- CBASS(presidential_speech)
   temp_file <- file.path(tempdir(), "tester.gif")
-  expect_no_warning(sv_res <- saveviz(cbass_fit, file.name = temp_file, type = "heatmap", image.type = "dynamic"))
+  expect_no_warning(sv_res <- saveviz(cbass_fit, file.name = temp_file, type = "heatmap", dynamic = TRUE))
   expect_equal(sv_res, invisible(temp_file))
   expect_true(file.exists(temp_file))
 })

--- a/tests/testthat/test_cbass_plot_save.R
+++ b/tests/testthat/test_cbass_plot_save.R
@@ -69,3 +69,14 @@ test_that("saveviz.CBASS can save a dynamic variable dendrogram as a GIF", {
   expect_equal(sv_res, invisible(temp_file))
   expect_true(file.exists(temp_file))
 })
+
+
+test_that("saveviz.CBASS can save a dynamic heatmap as a GIF", {
+  skip_on_cran()
+
+  cbass_fit <- CBASS(presidential_speech)
+  temp_file <- file.path(tempdir(), "tester.gif")
+  expect_no_warning(sv_res <- saveviz(cbass_fit, file.name = temp_file, type = "heatmap", image.type = "dynamic"))
+  expect_equal(sv_res, invisible(temp_file))
+  expect_true(file.exists(temp_file))
+})

--- a/tests/testthat/test_cbass_plot_save.R
+++ b/tests/testthat/test_cbass_plot_save.R
@@ -49,3 +49,23 @@ test_that("saveviz.CBASS can save a static variable dendrogram as a PDF", {
   expect_equal(invisible(temp_file), saveviz(cbass_fit, file.name = temp_file, type = "var.dendrogram", image.type = "static"))
   expect_true(file.exists(temp_file))
 })
+
+test_that("saveviz.CBASS can save a dynamic observation dendrogram as a GIF", {
+  skip_on_cran()
+
+  cbass_fit <- CBASS(presidential_speech)
+  temp_file <- file.path(tempdir(), "tester.gif")
+  expect_no_warning(sv_res <- saveviz(cbass_fit, file.name = temp_file, type = "obs.dendrogram", image.type = "dynamic"))
+  expect_equal(sv_res, invisible(temp_file))
+  expect_true(file.exists(temp_file))
+})
+
+test_that("saveviz.CBASS can save a dynamic variable dendrogram as a GIF", {
+  skip_on_cran()
+
+  cbass_fit <- CBASS(presidential_speech)
+  temp_file <- file.path(tempdir(), "tester.gif")
+  expect_no_warning(sv_res <- saveviz(cbass_fit, file.name = temp_file, type = "var.dendrogram", image.type = "dynamic"))
+  expect_equal(sv_res, invisible(temp_file))
+  expect_true(file.exists(temp_file))
+})

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -88,3 +88,18 @@ test_that("Converting plot dimensions works", {
   expect_equal(2.54,   convert_units(1, from = "in", to = "cm"))
   expect_equal(1/2.54, convert_units(1, from = "cm", to = "in"))
 })
+
+test_that("ensure_gif works", {
+  ensure_gif <- clustRviz:::ensure_gif
+
+  expect_equal("plot.gif", ensure_gif("plot.gif"))
+  expect_equal("~/plot.gif", ensure_gif("~/plot.gif"))
+  expect_equal("/my/long/path/plot.gif", ensure_gif("/my/long/path/plot.gif"))
+
+  expect_warning(ensure_gif("plot.jpg"))
+  expect_no_warning(ensure_gif("plot.gif"))
+
+  expect_equal("plot.gif", suppressWarnings(ensure_gif("plot.jpg")))
+  expect_equal("~/plot.gif", suppressWarnings(ensure_gif("~/plot.jpg")))
+  expect_equal("/my/long/path/plot.gif", suppressWarnings(ensure_gif("/my/long/path/plot.jpg")))
+})


### PR DESCRIPTION
This PR updates the gganimate api to the current supported version.

There are not as many changes as I originally thought; a previous version relied on gganimate much more extensively.

Changes are: 

* updated DESCRIPTION to bring install new api

* replace ggplot(aes(...,frame=)) w/ transition_manual()

* use gganimate::anim_save()

* updated namespace


