### PR TITLE
Use Matrix Algorithms

### DIFF
--- a/R/accessors_carp.R
+++ b/R/accessors_carp.R
@@ -228,8 +228,8 @@ get_U.CARP <- function(x, ..., percent, k){
   index <- which.min(abs(x$carp.sol.path$lambda.path - percent * max(x$carp.sol.path$lambda.path)))[1]
 
   raw_u <- matrix(x$carp.sol.path$u.path[, index],
-                  nrow = x$n.obs,
-                  ncol = x$p.var,
+                  nrow = x$n,
+                  ncol = x$p,
                   byrow = TRUE) # byrow = TRUE because we get u by vectorizing t(X), not X
 
   U <- unscale_matrix(raw_u, scale = x$scale_vector, center = x$center_vector)

--- a/R/carp.R
+++ b/R/carp.R
@@ -291,7 +291,7 @@ CARP <- function(X,
 #' @param ... Additional unused arguments
 #' @export
 #' @examples
-#' carp_fit <- CARP(presidential_speech[1:10,1:4])
+#' carp_fit <- CARP(presidential_speech)
 #' print(carp_fit)
 print.CARP <- function(x, ...) {
   alg_string <- switch(x$alg.type,
@@ -314,9 +314,6 @@ print.CARP <- function(x, ...) {
 
   cat("Weights:\n")
   print(x$weight_type)
-
-  cat("Raw Data:\n")
-  print(x$X[1:min(5, x$n), 1:min(5, x$p)])
 
   invisible(x)
 }

--- a/R/carp.R
+++ b/R/carp.R
@@ -42,8 +42,8 @@
 #' @return An object of class \code{CARP} containing the following elements (among others):
 #'         \itemize{
 #'         \item \code{X}: the original data matrix
-#'         \item \code{n.obs}: the number of observations (rows of \code{X})
-#'         \item \code{p.var}: the number of variables (columns of \code{X})
+#'         \item \code{n}: the number of observations (rows of \code{X})
+#'         \item \code{p}: the number of variables (columns of \code{X})
 #'         \item \code{alg.type}: the \code{CARP} variant used
 #'         \item \code{X.center}: a logical indicating whether \code{X} was centered
 #'                                column-wise before clustering
@@ -167,8 +167,8 @@ CARP <- function(X,
 
   rownames(X) <- labels <- make.unique(as.character(labels), sep="_")
 
-  n.obs <- NROW(X)
-  p.var <- NCOL(X)
+  n <- NROW(X)
+  p <- NCOL(X)
 
   # Center and scale X
   X.orig <- X
@@ -176,8 +176,8 @@ CARP <- function(X,
     X <- scale(X, center = X.center, scale = X.scale)
   }
 
-  scale_vector  <- attr(X, "scaled:scale", exact=TRUE)  %||% rep(1, p.var)
-  center_vector <- attr(X, "scaled:center", exact=TRUE) %||% rep(0, p.var)
+  scale_vector  <- attr(X, "scaled:scale", exact=TRUE)  %||% rep(1, p)
+  center_vector <- attr(X, "scaled:center", exact=TRUE) %||% rep(0, p)
 
   crv_message("Pre-computing weights and edge sets")
 
@@ -222,7 +222,7 @@ CARP <- function(X,
   edge_list <- which(weight_matrix_ut != 0, arr.ind = TRUE)
   edge_list <- edge_list[order(edge_list[, 1], edge_list[, 2]), ]
   cardE <- NROW(edge_list)
-  D <- matrix(0, ncol = n.obs, nrow = cardE)
+  D <- matrix(0, ncol = n, nrow = cardE)
   D[cbind(seq_len(cardE), edge_list[,1])] <-  1
   D[cbind(seq_len(cardE), edge_list[,2])] <- -1
 
@@ -280,8 +280,8 @@ CARP <- function(X,
     carp.cluster.path.vis = post_processing_results$paths,
     carp.sol.path = carp.sol.path,
     cardE = cardE,
-    n.obs = n.obs,
-    p.var = p.var,
+    n = n,
+    p = p,
     weight_type = weight_type,
     burn.in = burn.in,
     alg.type = alg.type,
@@ -324,8 +324,8 @@ print.CARP <- function(x, ...) {
   cat("Algorithm:", alg_string, "\n")
   cat("Time:", sprintf("%2.3f %s", x$time, attr(x$time, "units")), "\n\n")
 
-  cat("Number of Observations:", x$n.obs, "\n")
-  cat("Number of Variables:   ", x$p.var, "\n\n")
+  cat("Number of Observations:", x$n, "\n")
+  cat("Number of Variables:   ", x$p, "\n\n")
 
   cat("Pre-processing options:\n")
   cat(" - Columnwise centering:", x$X.center, "\n")
@@ -335,7 +335,7 @@ print.CARP <- function(x, ...) {
   print(x$weight_type)
 
   cat("Raw Data:\n")
-  print(x$X[1:min(5, x$n.obs), 1:min(5, x$p.var)])
+  print(x$X[1:min(5, x$n), 1:min(5, x$p)])
 
   invisible(x)
 }

--- a/R/cbass.R
+++ b/R/cbass.R
@@ -9,14 +9,14 @@
 #' @param X The data matrix (\eqn{X \in R^{n \times p}}{X}): rows correspond to
 #'          the observations (to be clustered) and columns to the variables (which
 #'          will not be clustered).
-#' @param obs_weights One of the following: \itemize{
+#' @param row_weights One of the following: \itemize{
 #'                    \item A function which, when called with argument \code{X},
 #'                          returns a n-by-n matrix of fusion weights.
 #'                    \item A matrix of size n-by-ncontaining fusion weights
 #'                    }
 #'                    Note that the weights will be renormalized to sum to
 #'                    \eqn{1/\sqrt{n}} internally.
-#' @param var_weights One of the following: \itemize{
+#' @param col_weights One of the following: \itemize{
 #'                    \item A function which, when called with argument \code{t(X)},
 #'                          returns a p-by-p matrix of fusion weights. (Note the
 #'                          transpose.)
@@ -24,8 +24,8 @@
 #'                    }
 #'                    Note that the weights will be renormalized to sum to
 #'                    \eqn{1/\sqrt{p}} internally.
-#' @param obs_labels A character vector of length \eqn{n}: observations (row) labels
-#' @param var_labels A character vector of length \eqn{p}: variable (column) labels
+#' @param row_labels A character vector of length \eqn{n}: row (observation) labels
+#' @param col_labels A character vector of length \eqn{p}: column (variable) labels
 #' @param X.center.global A logical: Should \code{X} be centered globally?
 #'                        \emph{I.e.}, should the global mean of \code{X} be subtracted?
 #' @param rho For advanced users only (not advisable to change): the penalty
@@ -85,16 +85,16 @@
 #' }
 CBASS <- function(X,
                   ...,
-                  var_weights = sparse_rbf_kernel_weights(k = "auto",
+                  row_weights = sparse_rbf_kernel_weights(k = "auto",
                                                           phi = "auto",
                                                           dist.method = "euclidean",
                                                           p = 2),
-                  obs_weights = sparse_rbf_kernel_weights(k = "auto",
+                  col_weights = sparse_rbf_kernel_weights(k = "auto",
                                                           phi = "auto",
                                                           dist.method = "euclidean",
                                                           p = 2),
-                  obs_labels = rownames(X),
-                  var_labels = colnames(X),
+                  row_labels = rownames(X),
+                  col_labels = colnames(X),
                   X.center.global = TRUE,
                   rho = 1.0,
                   t = 1.01,
@@ -173,26 +173,26 @@ CBASS <- function(X,
   }
 
   ## Get row (observation) labels
-  if (is.null(obs_labels)) {
-    obs_labels <- paste0("Obs", seq_len(NROW(X)))
+  if (is.null(row_labels)) {
+    row_labels <- paste0("Row", seq_len(NROW(X)))
   }
 
-  if ( length(obs_labels) != NROW(X) ){
-    crv_error(sQuote("obs_labels"), " must be of length ", sQuote("NROW(X)."))
+  if ( length(row_labels) != NROW(X) ){
+    crv_error(sQuote("row_labels"), " must be of length ", sQuote("NROW(X)."))
   }
 
-  rownames(X) <- obs_labels <- make.unique(as.character(obs_labels), sep = "_")
+  rownames(X) <- row_labels <- make.unique(as.character(row_labels), sep = "_")
 
   ## Get column (variable) labels
-  if (is.null(var_labels)) {
-    var_labels <- paste0("Var", seq_len(NCOL(X)))
+  if (is.null(col_labels)) {
+    col_labels <- paste0("Col", seq_len(NCOL(X)))
   }
 
-  if ( length(var_labels) != NCOL(X) ){
-    crv_error(sQuote("var_labels"), " must be of length ", sQuote("NCOL(X)."))
+  if ( length(col_labels) != NCOL(X) ){
+    crv_error(sQuote("col_labels"), " must be of length ", sQuote("NCOL(X)."))
   }
 
-  colnames(X) <- var_labels <- make.unique(as.character(var_labels), sep = "_")
+  colnames(X) <- col_labels <- make.unique(as.character(col_labels), sep = "_")
 
   n.obs <- NROW(X)
   p.var <- NCOL(X)
@@ -206,90 +206,82 @@ CBASS <- function(X,
     mean_adjust <- 0
   }
 
-  ## Transform to a form suitable for down-stream computation
-  X <- t(X) ## TODO: Ask JN why we keep this. (It matches the convention in Chi, Allen, Baraniuk)
+  crv_message("Pre-computing column weights and edge sets")
+  # Calculate column (variable/feature)-clustering weights
+  if (is.function(col_weights)) { # Usual case, `col_weights` is a function which calculates the weight matrix
+    col_weight_result <- col_weights(t(X))
+
+    if (is.matrix(col_weight_result)) {
+      col_weight_matrix <- col_weight_result
+      col_weight_type   <- UserFunction()
+    } else {
+      col_weight_matrix <- col_weight_result$weight_mat
+      col_weight_type   <- col_weight_result$type
+    }
+  } else if (is.matrix(col_weights)) {
+
+    if (!is_square(col_weights)) {
+      crv_error(sQuote("col_weights"), " must be a square matrix.")
+    }
+
+    if (NROW(col_weights) != NCOL(X)) {
+      crv_error(sQuote("NROW(col_weights)"), " must be equal to ", sQuote("NCOL(X)."))
+    }
+
+    col_weight_matrix <- col_weights
+    col_weight_type   <- UserMatrix()
+  } else {
+    crv_error(sQuote("CBASS"), " does not know how to handle ", sQuote("col_weights"),
+              " of class ", class(col_weights)[1], ".")
+  }
+
+  if (any(col_weight_matrix < 0) || anyNA(col_weight_matrix)) {
+    crv_error("All column fusion weights must be positive or zero.")
+  }
+
+  if (!is_connected_adj_mat(col_weight_matrix != 0)) {
+    crv_error("Weights for columns do not imply a connected graph. Biclustering will not succeed.")
+  }
 
   crv_message("Pre-computing row weights and edge sets")
+  # Calculate row (observation)-clustering weights
+  if (is.function(row_weights)) { # Usual case, `row_weights` is a function which calculates the weight matrix
+    row_weight_result <- row_weights(X)
 
-  # Calculate variable/feature (row)-clustering weights
-  if (is.function(var_weights)) { # Usual case, `var_weights` is a function which calculates the weight matrix
-    var_weight_result <- var_weights(X)
-
-    if (is.matrix(var_weight_result)) {
-      var_weight_matrix <- var_weight_result
-      var_weight_type   <- UserFunction()
+    if (is.matrix(row_weight_result)) {
+      row_weight_matrix <- row_weight_result
+      row_weight_type   <- UserFunction()
     } else {
-      var_weight_matrix <- var_weight_result$weight_mat
-      var_weight_type   <- var_weight_result$type
+      row_weight_matrix <- row_weight_result$weight_mat
+      row_weight_type   <- row_weight_result$type
     }
-  } else if (is.matrix(var_weights)) {
+  } else if (is.matrix(row_weights)) {
 
-    if (!is_square(var_weights)) {
-      crv_error(sQuote("var_weights"), " must be a square matrix.")
-    }
-
-    if (NROW(var_weights) != NROW(X)) {
-      crv_error(sQuote("NROW(var_weights)"), " must be equal to ", sQuote("NROW(X)."))
+    if (!is_square(row_weights)) {
+      crv_error(sQuote("row_weights"), " must be a square matrix.")
     }
 
-    var_weight_matrix <- var_weights
-    var_weight_type   <- UserMatrix()
+    if (NROW(row_weights) != NROW(X)) {
+      crv_error(sQuote("NROW(row_weights)"), " must be equal to ", sQuote("NROW(X)."))
+    }
+
+    row_weight_matrix <- row_weights
+    row_weight_type   <- UserMatrix()
   } else {
-    crv_error(sQuote("CBASS"), " does not know how to handle ", sQuote("var_weights"),
-         " of class ", class(var_weights)[1], ".")
+    crv_error(sQuote("CBASS"), " does not know how to handle ", sQuote("row_weights"),
+              " of class ", class(row_weights)[1], ".")
   }
 
-  if (any(var_weight_matrix < 0) || anyNA(var_weight_matrix)) {
-    crv_error("All fusion weights for variables must be positive or zero.")
+  if (any(row_weight_matrix < 0) || anyNA(row_weight_matrix)) {
+    crv_error("All row fusion weights must be positive or zero.")
   }
 
-  if (!is_connected_adj_mat(var_weight_matrix != 0)) {
-    crv_error("Weights for variables do not imply a connected graph. Biclustering will not succeed.")
+  if (!is_connected_adj_mat(row_weight_matrix != 0)) {
+    crv_error("Weights for rows do not imply a connected graph. Biclustering will not succeed.")
   }
 
-  crv_message("Pre-computing column weights and edge sets")
-
-  # Calculate observation (column)-clustering weights
-  if (is.function(obs_weights)) { # Usual case, `obs_weights` is a function which calculates the weight matrix
-    obs_weight_result <- obs_weights(t(X))
-
-    if (is.matrix(obs_weight_result)) {
-      obs_weight_matrix <- obs_weight_result
-      obs_weight_type   <- UserFunction()
-    } else {
-      obs_weight_matrix <- obs_weight_result$weight_mat
-      obs_weight_type   <- obs_weight_result$type
-    }
-  } else if (is.matrix(obs_weights)) {
-
-    if (!is_square(obs_weights)) {
-      crv_error(sQuote("obs_weights"), " must be a square matrix.")
-    }
-
-    if (NROW(obs_weights) != NCOL(X)) {
-      crv_error(sQuote("NROW(obs_weights)"), " must be equal to ", sQuote("NCOL(X)."))
-    }
-
-    obs_weight_matrix <- obs_weights
-    obs_weight_type   <- UserMatrix()
-  } else {
-    crv_error(sQuote("CBASS"), " does not know how to handle ", sQuote("obs_weights"),
-              " of class ", class(obs_weights)[1], ".")
-  }
-
-  if (any(obs_weight_matrix < 0) || anyNA(obs_weight_matrix)) {
-    crv_error("All fusion weights for observations must be positive or zero.")
-  }
-
-  if (!is_connected_adj_mat(obs_weight_matrix != 0)) {
-    crv_error("Weights for observations do not imply a connected graph. Clustering will not succeed.")
-  }
-
-  ## NB: We are following Chi, Allen, and Baraniuk so "row" here refers to
-  ##     features (variables) instead of the more typical observations
-  ##     and vice versa for columns
-  row_weights <- weight_mat_to_vec(var_weight_matrix)
-  col_weights <- weight_mat_to_vec(obs_weight_matrix)
+  row_weights <- weight_mat_to_vec(row_weight_matrix)
+  col_weights <- weight_mat_to_vec(col_weight_matrix)
 
   ## Rescale to ensure coordinated fusions
   ##
@@ -298,38 +290,33 @@ CBASS <- function(X,
   row_weights <- row_weights / (sum(row_weights) * sqrt(n.obs))
   col_weights <- col_weights / (sum(col_weights) * sqrt(p.var))
 
-  PreCompList.row <- ConvexClusteringPreCompute(X = t(X),
-                                                weights = row_weights,
-                                                rho = rho)
-  cardE.row <- NROW(PreCompList.row$E)
+  row_weight_matrix_ut <- row_weight_matrix * upper.tri(row_weight_matrix);
 
-  PreCompList.col <- ConvexClusteringPreCompute(X = X,
-                                                weights = col_weights,
-                                                rho = rho)
+  row_edge_list <- which(row_weight_matrix_ut != 0, arr.ind = TRUE)
+  row_edge_list <- row_edge_list[order(row_edge_list[, 1], row_edge_list[, 2]), ]
+  num_edge_rows <- NROW(row_edge_list)
+  D_row <- matrix(0, ncol = n.obs, nrow = num_edge_rows)
+  D_row[cbind(seq_len(num_edge_rows), row_edge_list[,1])] <-  1
+  D_row[cbind(seq_len(num_edge_rows), row_edge_list[,2])] <- -1
 
-  cardE.col <- NROW(PreCompList.col$E)
+  col_weight_matrix_ut <- col_weight_matrix * upper.tri(col_weight_matrix);
+
+  col_edge_list <- which(col_weight_matrix_ut != 0, arr.ind = TRUE)
+  col_edge_list <- col_edge_list[order(col_edge_list[, 1], col_edge_list[, 2]), ]
+  num_edge_cols <- NROW(col_edge_list)
+  D_col <- matrix(0, ncol = num_edge_cols, nrow = p.var)
+  D_col[cbind(col_edge_list[,1], seq_len(num_edge_cols))] <-  1
+  D_col[cbind(col_edge_list[,2], seq_len(num_edge_cols))] <- -1
 
   crv_message("Computing CBASS Path")
 
   if (alg.type %in% c("cbassviz", "cbassvizl1")) {
-    cbass.sol.path <- CBASS_VIZcpp(x = X[TRUE],
-                                   n = as.integer(n.obs),
-                                   p = as.integer(p.var),
+    cbass.sol.path <- CBASS_VIZcpp(X,
+                                   D_row,
+                                   D_col,
                                    lambda_init = 1e-6,
                                    weights_row = row_weights[row_weights != 0],
                                    weights_col = col_weights[col_weights != 0],
-                                   uinit_row = as.matrix(PreCompList.row$uinit),
-                                   uinit_col = as.matrix(PreCompList.col$uinit),
-                                   vinit_row = as.matrix(PreCompList.row$vinit),
-                                   vinit_col = as.matrix(PreCompList.col$vinit),
-                                   premat_row = PreCompList.row$PreMat,
-                                   premat_col = PreCompList.col$PreMat,
-                                   IndMat_row = PreCompList.row$ind.mat,
-                                   IndMat_col = PreCompList.col$ind.mat,
-                                   EOneIndMat_row = PreCompList.row$E1.ind.mat,
-                                   EOneIndMat_col = PreCompList.col$E1.ind.mat,
-                                   ETwoIndMat_row = PreCompList.row$E2.ind.mat,
-                                   ETwoIndMat_col = PreCompList.col$E2.ind.mat,
                                    rho = rho,
                                    max_iter = as.integer(max.iter),
                                    burn_in = burn.in,
@@ -338,25 +325,13 @@ CBASS <- function(X,
                                    keep = 10,
                                    l1 = (alg.type == "cbassvizl1"))
   } else {
-    cbass.sol.path <- CBASScpp(x = X[TRUE],
-                               n = as.integer(n.obs),
-                               p = as.integer(p.var),
+    cbass.sol.path <- CBASScpp(X,
+                               D_row,
+                               D_col,
                                lambda_init = 1e-6,
                                t = t,
                                weights_row = row_weights[row_weights != 0],
                                weights_col = col_weights[col_weights != 0],
-                               uinit_row = as.matrix(PreCompList.row$uinit),
-                               uinit_col = as.matrix(PreCompList.col$uinit),
-                               vinit_row = as.matrix(PreCompList.row$vinit),
-                               vinit_col = as.matrix(PreCompList.col$vinit),
-                               premat_row = PreCompList.row$PreMat,
-                               premat_col = PreCompList.col$PreMat,
-                               IndMat_row = PreCompList.row$ind.mat,
-                               IndMat_col = PreCompList.col$ind.mat,
-                               EOneIndMat_row = PreCompList.row$E1.ind.mat,
-                               EOneIndMat_col = PreCompList.col$E1.ind.mat,
-                               ETwoIndMat_row = PreCompList.row$E2.ind.mat,
-                               ETwoIndMat_col = PreCompList.col$E2.ind.mat,
                                rho = rho,
                                max_iter = as.integer(max.iter),
                                burn_in = burn.in,
@@ -374,24 +349,24 @@ CBASS <- function(X,
   crv_message("Post-processing rows")
 
   post_processing_results_row <- ConvexClusteringPostProcess(X = X,
-                                                             edge_matrix      = PreCompList.row$E,
+                                                             edge_matrix      = row_edge_list,
                                                              lambda_path      = cbass.sol.path$lambda.path,
                                                              u_path           = cbass.sol.path$u.path,
                                                              v_path           = cbass.sol.path$v.row.path,
                                                              v_zero_indices   = cbass.sol.path$v.row.zero.inds,
-                                                             labels           = var_labels,
+                                                             labels           = row_labels,
                                                              dendrogram_scale = dendrogram.scale,
                                                              npcs             = npcs)
 
   crv_message("Post-processing columns")
 
   post_processing_results_col <- ConvexClusteringPostProcess(X = t(X),
-                                                             edge_matrix      = PreCompList.col$E,
+                                                             edge_matrix      = col_edge_list,
                                                              lambda_path      = cbass.sol.path$lambda.path,
                                                              u_path           = cbass.sol.path$u.path,
                                                              v_path           = cbass.sol.path$v.col.path,
                                                              v_zero_indices   = cbass.sol.path$v.col.zero.inds,
-                                                             labels           = obs_labels,
+                                                             labels           = col_labels,
                                                              dendrogram_scale = dendrogram.scale,
                                                              npcs             = npcs)
 
@@ -400,18 +375,18 @@ CBASS <- function(X,
     n.obs = n.obs,
     p.var = p.var,
     cbass.sol.path = cbass.sol.path,
-    # Rowwise (variable) results
-    cbass.cluster.path.var = post_processing_results_row$raw_path,
-    cbass.cluster.path.vis.var = post_processing_results_row$paths,
-    cbass.dend.var = post_processing_results_row$dendrogram,
-    var_weight_type = var_weight_type,
-    var.labels = var_labels,
-    # Columnwise (observation) results
-    cbass.cluster.path.obs = post_processing_results_col$raw_path,
-    cbass.cluster.path.vis.obs = post_processing_results_col$paths,
-    cbass.dend.obs = post_processing_results_col$dendrogram,
-    obs_weight_type = obs_weight_type,
-    obs.labels = obs_labels,
+    # Column-wise (variable) results
+    cbass.cluster.path.var = post_processing_results_col$raw_path,
+    cbass.cluster.path.vis.var = post_processing_results_col$paths,
+    cbass.dend.var = post_processing_results_col$dendrogram,
+    var_weight_type = col_weight_type,
+    var.labels = col_labels,
+    # Row-wise (observation) results
+    cbass.cluster.path.obs = post_processing_results_row$raw_path,
+    cbass.cluster.path.vis.obs = post_processing_results_row$paths,
+    cbass.dend.obs = post_processing_results_row$dendrogram,
+    obs_weight_type = row_weight_type,
+    obs.labels = row_labels,
     # General flags
     burn.in = burn.in,
     alg.type = alg.type,

--- a/R/cbass.R
+++ b/R/cbass.R
@@ -392,7 +392,7 @@ CBASS <- function(X,
 #' @param ... Additional unused arguments
 #' @export
 #' @examples
-#' cbass_fit <- CBASS(X=presidential_speech[1:10,1:4])
+#' cbass_fit <- CBASS(X=presidential_speech)
 #' print(cbass_fit)
 print.CBASS <- function(x, ...) {
   alg_string <- switch(x$alg.type,
@@ -417,9 +417,6 @@ print.CBASS <- function(x, ...) {
 
   cat("Column Weights:\n")
   print(x$col_weight_type)
-
-  cat("Raw Data:\n")
-  print(x$X[1:min(5, x$n), 1:min(5, x$p)])
 
   invisible(x)
 }

--- a/R/options.R
+++ b/R/options.R
@@ -1,0 +1,107 @@
+## clustRviz options
+
+clustRviz_default_options <- list(rho                = 1.0,
+                                  max_iter           = 10000L,
+                                  burn_in            = 50L,
+                                  viz_initial_step   = 1.1,
+                                  viz_small_step     = 1.01,
+                                  viz_max_inner_iter = 15L,
+                                  keep               = 10L,
+                                  epsilon            = 0.000001)
+
+.clustRvizOptionsEnv <- list2env(clustRviz_default_options)
+
+#' \code{ClustRViz} Options
+#'
+#' Advanced control of algorithmic options for \code{\link{CARP}} and \code{\link{CBASS}}.
+#' The \code{clustRviz_reset_options} function returns options to "factory-fresh"
+#' settings.
+#'
+#' @param ... Options (to be passed by name). See below for available options.
+#'
+#' @details The following options can be set by name:\itemize{
+#'   \item \code{epsilon} The initial step size (fixed during the "burn-in" period)
+#'   \item \code{max_iter} An integer: the maximum number of iterations to perform.
+#'   \item \code{burn_in} An integer: the number of initial iterations at a fixed
+#'                       (small) value of \eqn{\gamma}
+#'   \item \code{viz_initial_step} The initial (large) step size used in back-tracking
+#'                                 (\code{CARP-VIZ} and \code{CBASS-VIZ}) algorithms.
+#'   \item \code{viz_small_step} The secondary (small) step size used in back-tracking
+#'                               (\code{CARP-VIZ} and \code{CBASS-VIZ}) algorithms.
+#'   \item \code{viz_max_inner_iter} The maximum number of iterations to perform
+#'                                   in the inner loop of back-tracking (\code{CARP-VIZ}
+#'                                   and \code{CBASS-VIZ}) algorithms.
+#'   \item \code{keep} \code{\link{CARP}} and \code{\link{CBASS}} keep every
+#'                     \code{keep}-th iteration even if no fusions are detected.
+#'                     Increasing this parameter may improve performance, at
+#'                     the expense of returning a finer grid.
+#'   \item \code{rho} For advanced users only (not advisable to change): the penalty
+#'                    parameter used for the augmented Lagrangian.
+#' }
+#' @rdname options
+#' @export
+clustRviz_options <- function(...){
+  dots <- list(...)
+
+  if (length(dots) == 0){
+    return(as.list(.clustRvizOptionsEnv))
+  }
+
+  if (is.list(dots[[1]])) {
+    dots <- do.call(c, dots)
+  }
+
+  if ( (is.null(names(dots))) || (any(names(dots) == "")) ){
+    crv_error("All arguments to ", sQuote("clustRviz_options"), " must be named.")
+  }
+
+  known_names <- names(.clustRvizOptionsEnv)
+
+  if ( any(names(dots) %not.in% known_names) ){
+    unknown_names <- which(names(dots) %not.in% known_names)
+    crv_error("Unknown argument ", sQuote(names(dots)[unknown_names[1]]), " passed to ", sQuote("clustRviz_options."))
+  }
+
+  old_opts <- as.list(.clustRvizOptionsEnv)
+
+  for(ix in seq_along(dots)){
+    nm  <- names(dots)[ix]
+    opt <- dots[[ix]]
+
+    ## Validate
+    if (nm %in% c("rho", "epsilon")) {
+      if (!is_positive_scalar(opt)) {
+        crv_error(sQuote(nm), " must be a positive scalar.")
+      }
+    } else if (nm %in% c("viz_initial_step", "viz_small_step")) {
+      if ( (!is_positive_scalar(opt)) || (opt <= 1) ){
+        crv_error(sQuote(nm), " must be greater than one.")
+      }
+    } else if (nm %in% c("burn_in", "max_iter", "viz_burn_in", "viz_max_inner_iter", "keep")) {
+      if (!is_positive_integer_scalar(opt) ){
+        crv_error(sQuote(nm), " must be a positive integer.")
+      }
+    }
+
+    ## Assign
+    assign(nm, opt, .clustRvizOptionsEnv)
+  }
+
+  ## Sanity checks
+  if (.clustRvizOptionsEnv[["burn_in"]] + 100 >= .clustRvizOptionsEnv[["max_iter"]]) {
+    crv_warning(sQuote("burn_in"), " should typically be at least 100 less than ", sQuote("max_iter."))
+  }
+
+  if (.clustRvizOptionsEnv[["viz_small_step"]] >= .clustRvizOptionsEnv[["viz_initial_step"]]) {
+    crv_warning(sQuote("viz_small_step"), " should be less than ", sQuote("viz_initial_step."))
+  }
+
+  ##
+  invisible(old_opts)
+}
+
+#' @rdname options
+#' @export
+clustRviz_reset_options <- function(){
+  do.call(clustRviz_options, clustRviz_default_options)
+}

--- a/R/plot_cbass.R
+++ b/R/plot_cbass.R
@@ -3,14 +3,14 @@
 #' \code{plot.CBASS} provides a range of ways to visualize the results of convex
 #' clustering, including: \itemize{
 #' \item Dendrograms, illustrating the nested cluster hierarchy inferred from
-#'       the convex clustering solution path (\code{type = "obs.dendrogram"} and
-#'       \code{type = "var.dendrogram"} for the observation and feature / variable
-#'       clusterings, respectively);
+#'       the convex clustering solution path (\code{type = "row.dendrogram"} and
+#'       \code{type = "col.dendrogram"} for the row (observation) and column
+#'       (feature / variable) clusterings, respectively);
 #' \item Path plots, showing the coalescence of the estimated cluster centroids
-#'       as the regularization parameter is increased (\code{type = "obs.dendrogram"}
-#'       and \code{type = "var.dendrogram"} for the observation and feature / variable
-#'       clusterings, respectively);
-#' \item A cluster heatmap, displaying observation and feature histograms, as well
+#'       as the regularization parameter is increased (\code{type = "row.dendrogram"}
+#'       and \code{type = "col.dendrogram"} for the row (observation) and column
+#'       (feature / variable) clusterings, respectively);
+#' \item A cluster heatmap, displaying row and column histograms, as well
 #'       as the clustered data matrix in a single graphic (\code{type = "heatmap"}); and
 #' \item A \code{\link[shiny]{shiny}} app, which can display the clustering solutions
 #'       as a "movie" or allow for interactive exploration (\code{type = "interactive"}).
@@ -26,24 +26,24 @@
 #'                a fraction of the final regularization level used) at which to
 #'                assign clusters in the static (\code{type = "dendrogram"} or \code{type = "path"})
 #'                plots.
-#' @param k.obs An integer indicating the desired number of observation clusters to be displayed
-#'              in the static plots. (If plotting variables, the regularization level
-#'              giving \code{k.obs} observation clusters is used.)
-#' @param k.var An integer indicating the desired number of feature clusters to be displayed
-#'              in the static plots. (If plotting variables, the regularization level
-#'              giving \code{k.var} feature clusters is used.)
+#' @param k.row An integer indicating the desired number of row clusters to be displayed
+#'              in the static plots. (If plotting columns, the regularization level
+#'              giving \code{k.row} rows clusters is used.)
+#' @param k.col An integer indicating the desired number of column clusters to be displayed
+#'              in the static plots. (If plotting rows, the regularization level
+#'              giving \code{k.col} column clusters is used.)
 #' @param ... Additional arguments. Currently an error when \code{type} is not
-#'            \code{"obs.dendrogram"} or \code{"var.dendrogram"}; passed to
-#'            \code{\link[stats]{plot.dendrogram}} when \code{type == "obs.dendrogram"}
-#'            or \code{type == "var.dendrogram"}.
+#'            \code{"row.dendrogram"} or \code{"col.dendrogram"}; passed to
+#'            \code{\link[stats]{plot.dendrogram}} when \code{type == "row.dendrogram"}
+#'            or \code{type == "col.dendrogram"}.
 #' @param dend.branch.width a positive number. Line width on dendrograms.
 #' @param dend.labels.cex a positive number. Label size on dendrograms.
 #' @param heatrow.label.cex heatmap row label size
 #' @param heatcol.label.cex heatmap column label size
 #' @return The value of the return type depends on the \code{type} argument:\itemize{
-#'  \item if \code{type \%in\% c("obs.dendrogram", "var.dendrogram", "heatmap")},
+#'  \item if \code{type \%in\% c("row.dendrogram", "col.dendrogram", "heatmap")},
 #'         \code{x} is returned invisibly;
-#'  \item if \code{type \%in\% c("obs.path", "var.path")}, an object of class
+#'  \item if \code{type \%in\% c("row.path", "col.path")}, an object of class
 #'        \code{\link[ggplot2]{ggplot}} which can be plotted directly (by invoking
 #'        its print method) or modified further by the user is returned;
 #'  \item if \code{type = "interactive"}, a \code{\link[shiny]{shiny}} app which can be activated
@@ -51,7 +51,7 @@
 #' } \code{saveviz.CBASS} always returns \code{file.name} invisibly.
 #' @details The \code{\link{saveviz.CBASS}} function provides a unified interface
 #'          for exporting \code{CBASS} visualizations to files. For all plots,
-#'          at most one of \code{percent}, \code{k.obs}, and \code{k.var} must be supplied.
+#'          at most one of \code{percent}, \code{k.row}, and \code{k.col} must be supplied.
 #' @importFrom shiny shinyApp fluidPage titlePanel tabsetPanel fluidRow animationOptions
 #' @importFrom shiny tags column plotOutput renderPlot sliderInput
 #' @importFrom stats as.dendrogram as.hclust quantile
@@ -66,14 +66,14 @@
 plot.CBASS <- function(x,
                        ...,
                        type = c("heatmap",
-                                "obs.dendrogram",
-                                "var.dendrogram",
-                                "obs.path",
-                                "var.path",
+                                "row.dendrogram",
+                                "col.dendrogram",
+                                "row.path",
+                                "col.path",
                                 "interactive"),
                        percent,
-                       k.obs,
-                       k.var,
+                       k.row,
+                       k.col,
                        dend.branch.width = 2,
                        dend.labels.cex = .6,
                        heatrow.label.cex = 1.5,
@@ -84,50 +84,50 @@ plot.CBASS <- function(x,
 
   switch(
     type,
-    obs.dendrogram = {
+    row.dendrogram = {
       cbass_dendro_plot(x,
                         percent = percent,
-                        k.obs = k.obs,
-                        k.var = k.var,
+                        k.row = k.row,
+                        k.col = k.col,
                         dend.branch.width = dend.branch.width,
                         dend.labels.cex = dend.labels.cex,
-                        type = "obs",
+                        type = "row",
                         ...)
     },
-    var.dendrogram = {
+    col.dendrogram = {
       cbass_dendro_plot(x,
                         percent = percent,
-                        k.obs = k.obs,
-                        k.var = k.var,
+                        k.row = k.row,
+                        k.col = k.col,
                         dend.branch.width = dend.branch.width,
                         dend.labels.cex = dend.labels.cex,
-                        type = "var",
+                        type = "col",
                         ...)
     },
-    obs.path = {
+    row.path = {
       cbass_path_plot(x,
                      axis = axis,
                      percent = percent,
-                     k.obs = k.obs,
-                     k.var = k.var,
+                     k.row = k.row,
+                     k.col = k.col,
                      ...,
-                     type = "obs")
+                     type = "row")
     },
-    var.path = {
+    col.path = {
       cbass_path_plot(x,
                       axis = axis,
                       percent = percent,
-                      k.obs = k.obs,
-                      k.var = k.var,
+                      k.row = k.row,
+                      k.col = k.col,
                       ...,
-                      type = "var")
+                      type = "col")
     },
     heatmap = {
       cbass_heatmap_plot(x,
                          ...,
                          percent = percent,
-                         k.obs = k.obs,
-                         k.var = k.var,
+                         k.row = k.row,
+                         k.col = k.col,
                          heatrow.label.cex = heatrow.label.cex,
                          heatcol.label.cex = heatcol.label.cex)
     },
@@ -181,8 +181,8 @@ plot.CBASS <- function(x,
             X.heat <- t(x$X)
             X <- t(x$X)
           }
-          colnames(X.heat) <- x$obs.labels
-          rownames(X.heat) <- x$var.labels
+          colnames(X.heat) <- x$row.labels
+          rownames(X.heat) <- x$col.labels
           x$cbass.sol.path$lambda.path %>% as.vector() -> lam.seq
           lam.prop.seq <- lam.seq / max(lam.seq)
           nbreaks <- 50
@@ -197,15 +197,15 @@ plot.CBASS <- function(x,
             cur.lam <- x$cbass.sol.path$lambda.path[plt.iter]
             cur.lam
             # find lambda closest in column path
-            cur.col.lam.ind <- which.min(abs(x$cbass.cluster.path.obs$lambda.path.inter - cur.lam))
+            cur.col.lam.ind <- which.min(abs(x$cbass.cluster.path.row$lambda.path.inter - cur.lam))
             # find clustering solution in column path
-            cur.col.clust.assignment <- x$cbass.cluster.path.obs$clust.path[[cur.col.lam.ind]]$membership
+            cur.col.clust.assignment <- x$cbass.cluster.path.row$clust.path[[cur.col.lam.ind]]$membership
             cur.col.clust.labels <- unique(cur.col.clust.assignment)
             cur.col.nclust <- length(cur.col.clust.labels)
             # find lambda closest in row path
-            cur.row.lam.ind <- which.min(abs(x$cbass.cluster.path.var$lambda.path.inter - cur.lam))
+            cur.row.lam.ind <- which.min(abs(x$cbass.cluster.path.col$lambda.path.inter - cur.lam))
             # find clustering solution in row path
-            cur.row.clust.assignment <- x$cbass.cluster.path.var$clust.path[[cur.row.lam.ind]]$membership
+            cur.row.clust.assignment <- x$cbass.cluster.path.col$clust.path[[cur.row.lam.ind]]$membership
             cur.row.clust.labels <- unique(cur.row.clust.assignment)
             cur.row.nclust <- length(cur.row.clust.labels)
             for (col.label.ind in seq_along(cur.col.clust.labels)) {
@@ -221,16 +221,16 @@ plot.CBASS <- function(x,
             my.heatmap.2(
               x = X.heat,
               scale = "none",
-              Colv = stats::as.dendrogram(x$cbass.dend.obs),
-              Rowv = stats::as.dendrogram(x$cbass.dend.var),
+              Colv = stats::as.dendrogram(x$cbass.dend.row),
+              Rowv = stats::as.dendrogram(x$cbass.dend.col),
               trace = "none",
               density.info = "none",
               key = FALSE,
               breaks = breaks,
               col = heatcols,
               symkey = F,
-              Row.hclust = x$cbass.dend.var %>% stats::as.hclust(),
-              Col.hclust = x$cbass.dend.obs %>% stats::as.hclust(),
+              Row.hclust = x$cbass.dend.col %>% stats::as.hclust(),
+              Col.hclust = x$cbass.dend.row %>% stats::as.hclust(),
               k.col = cur.col.nclust,
               k.row = cur.row.nclust,
               my.col.vec = my.cols,
@@ -254,9 +254,9 @@ cbass_path_plot <- function(x,
                             ...,
                             axis,
                             percent,
-                            k.obs,
-                            k.var,
-                            type = c("obs", "var")){
+                            k.row,
+                            k.col,
+                            type = c("row", "col")){
 
   type <- match.arg(type)
 
@@ -272,16 +272,16 @@ cbass_path_plot <- function(x,
   }
 
   has_percent <- !missing(percent)
-  has_k.obs   <- !missing(k.obs)
-  has_k.var   <- !missing(k.var)
+  has_k.row   <- !missing(k.row)
+  has_k.col   <- !missing(k.col)
 
-  n_args <- has_percent + has_k.obs + has_k.var
+  n_args <- has_percent + has_k.row + has_k.col
 
   show_clusters <- (n_args == 1)
 
   if(n_args > 1){
-    crv_error("At most one of ", sQuote("percent"), " ", sQuote("k.obs"), " and ",
-              sQuote("k.var"), " may be supplied.")
+    crv_error("At most one of ", sQuote("percent"), " ", sQuote("k.row"), " and ",
+              sQuote("k.col"), " may be supplied.")
   }
 
   if (n_args == 0L) {
@@ -299,7 +299,7 @@ cbass_path_plot <- function(x,
     "LambdaPercent"
   )
 
-  path_obj <- if(type == "obs") x$cbass.cluster.path.vis.obs else x$cbass.cluster.path.vis.var
+  path_obj <- if(type == "row") x$cbass.cluster.path.vis.row else x$cbass.cluster.path.vis.col
 
   if (any(plot_cols %not.in% colnames(path_obj))) {
     missing_col <- plot_cols[which(plot_cols %not.in% colnames(path_obj))][1]
@@ -310,45 +310,45 @@ cbass_path_plot <- function(x,
                                   filter(.data$Iter > x$burn.in)
   names(plot_frame_full)[1:2] <- c("V1", "V2")
 
-  if(has_k.obs){
+  if(has_k.row){
 
-    if ( !is_integer_scalar(k.obs) ){
+    if ( !is_integer_scalar(k.row) ){
       crv_error(sQuote("k"), " must be an integer scalar (vector of length 1).")
     }
 
-    if( k.obs <= 0 ) {
-      crv_error(sQuote("k.obs"), " must be positive.")
+    if( k.row <= 0 ) {
+      crv_error(sQuote("k.row"), " must be positive.")
     }
 
-    if( k.obs > NROW(x$X) ){
-      crv_error(sQuote("k.obs"), " cannot be more than the observations in the original data set (", NROW(x$X), ").")
+    if( k.row > NROW(x$X) ){
+      crv_error(sQuote("k.row"), " cannot be more than the rows in the original data set (", NROW(x$X), ").")
     }
 
-    percent <- x$cbass.cluster.path.vis.obs %>%
+    percent <- x$cbass.cluster.path.vis.row %>%
       select(.data$LambdaPercent, .data$NCluster) %>%
-      filter(.data$NCluster <= k.obs) %>%
+      filter(.data$NCluster <= k.row) %>%
       select(.data$LambdaPercent) %>%
       summarize(percent = min(.data$LambdaPercent)) %>%
       pull
   }
 
-  if(has_k.var){
+  if(has_k.col){
 
-    if ( !is_integer_scalar(k.var) ){
+    if ( !is_integer_scalar(k.col) ){
       crv_error(sQuote("k"), " must be an integer scalar (vector of length 1).")
     }
 
-    if( k.var <= 0 ) {
-      crv_error(sQuote("k.var"), " must be positive.")
+    if( k.col <= 0 ) {
+      crv_error(sQuote("k.col"), " must be positive.")
     }
 
-    if( k.var > NCOL(x$X) ){
-      crv_error(sQuote("k.var"), " cannot be more than the features in the original data set (", NCOL(x$X), ").")
+    if( k.col > NCOL(x$X) ){
+      crv_error(sQuote("k.col"), " cannot be more than the columns in the original data set (", NCOL(x$X), ").")
     }
 
-    percent <- x$cbass.cluster.path.vis.var %>%
+    percent <- x$cbass.cluster.path.vis.col %>%
       select(.data$LambdaPercent, .data$NCluster) %>%
-      filter(.data$NCluster <= k.var) %>%
+      filter(.data$NCluster <= k.col) %>%
       select(.data$LambdaPercent) %>%
       summarize(percent = min(.data$LambdaPercent)) %>%
       pull
@@ -398,11 +398,11 @@ cbass_path_plot <- function(x,
 #' @importFrom grDevices adjustcolor
 cbass_dendro_plot <- function(x,
                              percent,
-                             k.obs,
-                             k.var,
+                             k.row,
+                             k.col,
                              dend.branch.width = 2,
                              dend.labels.cex = .6,
-                             type = c("obs", "var"),
+                             type = c("row", "col"),
                              ...){
 
   type <- match.arg(type)
@@ -416,18 +416,18 @@ cbass_dendro_plot <- function(x,
   }
 
   has_percent <- !missing(percent)
-  has_k.obs   <- !missing(k.obs)
-  has_k.var   <- !missing(k.var)
-  n_args      <- has_percent + has_k.obs + has_k.var
+  has_k.row   <- !missing(k.row)
+  has_k.col   <- !missing(k.col)
+  n_args      <- has_percent + has_k.row + has_k.col
 
   show_clusters <- (n_args == 1)
 
   if(n_args > 1){
-    crv_error("At most one of ", sQuote("percent"), " ", sQuote("k.obs"), " and ",
-         sQuote("k.var"), " may be supplied.")
+    crv_error("At most one of ", sQuote("percent"), " ", sQuote("k.row"), " and ",
+         sQuote("k.col"), " may be supplied.")
   }
 
-  dend <- if(type == "obs") x$cbass.dend.obs else x$cbass.dend.var
+  dend <- if(type == "row") x$cbass.dend.row else x$cbass.dend.col
 
   ## Set better default margins
   par(mar = c(14, 7, 2, 1))
@@ -438,7 +438,7 @@ cbass_dendro_plot <- function(x,
            plot(ylab = "Amount of Regularization", cex.lab = 1.5, ...)
 
   if(show_clusters){
-    labels <- get_cluster_labels(x, k.obs = k.obs, k.var = k.var, percent = percent, type = type)
+    labels <- get_cluster_labels(x, k.row = k.row, k.col = k.col, percent = percent, type = type)
     n_clusters <- nlevels(labels)
 
     my.cols <- adjustcolor(c("grey", "black"), alpha.f = .2)
@@ -453,8 +453,8 @@ cbass_dendro_plot <- function(x,
 cbass_heatmap_plot <- function(x,
                                ...,
                                percent,
-                               k.obs,
-                               k.var,
+                               k.row,
+                               k.col,
                                heatrow.label.cex,
                                heatcol.label.cex,
                                breaks = NULL,
@@ -467,24 +467,25 @@ cbass_heatmap_plot <- function(x,
   }
 
   has_percent <- !missing(percent)
-  has_k.obs   <- !missing(k.obs)
-  has_k.var   <- !missing(k.var)
+  has_k.row   <- !missing(k.row)
+  has_k.col   <- !missing(k.col)
 
-  n_args <- has_percent + has_k.obs + has_k.var
+  n_args <- has_percent + has_k.row + has_k.col
 
   if(n_args >= 2){
-    crv_error("At most one of ", sQuote("percent,"), " ", sQuote("k.obs"), " and ",
-              sQuote("k.var"), " may be supplied.")
+    crv_error("At most one of ", sQuote("percent,"), " ", sQuote("k.row"), " and ",
+              sQuote("k.col"), " may be supplied.")
   }
 
   if(n_args == 0){
     U     <- get_clustered_data(x, percent = 0, refit = TRUE)
-    k.col <- NCOL(U) ## FIXME - why is this backwards?
-    k.row <- NROW(U)
+    n.row <- NROW(U)
+    n.col <- NCOL(U)
   } else {
-    U <- get_clustered_data(x, percent = percent, k.obs = k.obs, k.var = k.var, refit = TRUE)
-    k.row <- nlevels(get_cluster_labels(x, percent = percent, k.obs = k.obs, k.var = k.var, type = "obs"))
-    k.col <- nlevels(get_cluster_labels(x, percent = percent, k.obs = k.obs, k.var = k.var, type = "var"))
+    U <- get_clustered_data(x, percent = percent, k.row = k.row, k.col = k.col, refit = TRUE)
+    # Note that we can't assign n.row / n.col here since we might confuse it with user-supplied arguments
+    n.row <- nlevels(get_cluster_labels(x, percent = percent, k.row = k.row, k.col = k.col, type = "row"))
+    n.col <- nlevels(get_cluster_labels(x, percent = percent, k.row = k.row, k.col = k.col, type = "col"))
   }
 
   if (heatrow.label.cex < 0) {
@@ -498,7 +499,9 @@ cbass_heatmap_plot <- function(x,
   if (is.null(breaks)) {
     nbreaks <- 50
     quant.probs <- seq(0, 1, length.out = nbreaks)
-    breaks <- unique(quantile(as.vector(U), probs = quant.probs))
+    ## Rarely (when there are ties involved) the result of unique(quantile(...))
+    ## isn't quite sorted, so we fix things up manually
+    breaks <- sort(unique(quantile(as.vector(U), probs = quant.probs)))
   }
 
   if (is.null(heatmap_col)) {
@@ -511,18 +514,18 @@ cbass_heatmap_plot <- function(x,
   my.heatmap.2(
     x = U,
     scale = "none",
-    Rowv = as.dendrogram(x$cbass.dend.obs),
-    Colv = as.dendrogram(x$cbass.dend.var),
+    Rowv = as.dendrogram(x$cbass.dend.row),
+    Colv = as.dendrogram(x$cbass.dend.col),
     trace = "none",
     density.info = "none",
     key = FALSE,
     breaks = breaks,
     col = heatmap_col,
     symkey = FALSE,
-    Row.hclust = as.hclust(x$cbass.dend.obs),
-    Col.hclust = as.hclust(x$cbass.dend.var),
-    k.col = k.col,
-    k.row = k.row,
+    Row.hclust = as.hclust(x$cbass.dend.row),
+    Col.hclust = as.hclust(x$cbass.dend.col),
+    k.col = n.col,
+    k.row = n.row,
     my.col.vec = my.cols,
     cexRow = heatrow.label.cex,
     cexCol = heatcol.label.cex,

--- a/R/save.R
+++ b/R/save.R
@@ -117,8 +117,8 @@ saveviz.CARP <- function(x,
 #'                If \code{TRUE}, a dynamic visualization which varies along the
 #'                \code{CARP} solution path at a grid given by \code{percent.seq}
 #'                is produced (as a \code{GIF}). If \code{FALSE}, a fixed visualization
-#'                at a single solution (determined by \code{percent}, \code{k.obs} or
-#'                \code{k.var} if supplied) is produced.
+#'                at a single solution (determined by \code{percent}, \code{k.row} or
+#'                \code{k.col} if supplied) is produced.
 #' @param percent.seq A grid of values of \code{percent} along which to generate
 #'                    dynamic visualizations (if \code{dynamic == TRUE})
 #' @param width The width of the output, given in \code{unit}s
@@ -133,15 +133,15 @@ saveviz.CARP <- function(x,
 #' @export
 saveviz.CBASS <- function(x,
                           file.name,
-                          type = c("heatmap", "obs.dendrogram", "var.dendrogram"),
+                          type = c("heatmap", "row.dendrogram", "col.dendrogram"),
                           dynamic = TRUE,
                           dend.branch.width = 2,
                           dend.labels.cex = .6,
                           heatrow.label.cex = 1.5,
                           heatcol.label.cex = 1.5,
                           percent,
-                          k.obs,
-                          k.var,
+                          k.row,
+                          k.col,
                           percent.seq = seq(from = 0, to = 1, by = .05),
                           width = 8,
                           height = 5,
@@ -167,33 +167,33 @@ saveviz.CBASS <- function(x,
              cbass_heatmap_plot(x,
                                 ...,
                                 percent = percent,
-                                k.obs = k.obs,
-                                k.var = k.var,
+                                k.row = k.row,
+                                k.col = k.col,
                                 heatrow.label.cex = heatrow.label.cex,
                                 heatcol.label.cex = heatcol.label.cex)
              dev.off()
            },
-           obs.dendrogram = {
+           row.dendrogram = {
              crv_new_dev_static(file.name, width = width, height = height, units = units)
              cbass_dendro_plot(x,
                                percent = percent,
-                               k.obs = k.obs,
-                               k.var = k.var,
+                               k.row = k.row,
+                               k.col = k.col,
                                dend.branch.width = dend.branch.width,
                                dend.labels.cex = dend.labels.cex,
-                               type = "obs",
+                               type = "row",
                                ...)
              dev.off()
            },
-           var.dendrogram = {
+           col.dendrogram = {
              crv_new_dev_static(file.name, width = width, height = height, units = units)
              cbass_dendro_plot(x,
                                percent = percent,
-                               k.obs = k.obs,
-                               k.var = k.var,
+                               k.row = k.row,
+                               k.col = k.col,
                                dend.branch.width = dend.branch.width,
                                dend.labels.cex = dend.labels.cex,
-                               type = "var",
+                               type = "col",
                                ...)
              dev.off()
            })
@@ -232,35 +232,35 @@ saveviz.CBASS <- function(x,
          clean = TRUE)
       invisible(file.name)
     },
-    obs.dendrogram = {
+    row.dendrogram = {
       animation::saveGIF({
         for (pct in percent.seq) {
           cbass_dendro_plot(x,
                             percent = pct,
                             dend.branch.width = dend.branch.width,
                             dend.labels.cex = dend.labels.cex,
-                            type = "obs",
+                            type = "row",
                             ...)
         }
       }, movie.name = file.name,
-         img.name = "cbass_observation_dendrogram",
+         img.name = "cbass_row_dendrogram",
          ani.width  = convert_units(width, from = units, to = "px"),
          ani.height = convert_units(height, from = units, to = "px"),
          clean = TRUE)
       invisible(file.name)
     },
-    var.dendrogram = {
+    col.dendrogram = {
       animation::saveGIF({
         for (pct in percent.seq) {
           cbass_dendro_plot(x,
                             percent = pct,
                             dend.branch.width = dend.branch.width,
                             dend.labels.cex = dend.labels.cex,
-                            type = "obs",
+                            type = "col",
                             ...)
         }
       }, movie.name = file.name,
-         img.name = "cbass_variable_dendrogram",
+         img.name = "cbass_column_dendrogram",
          ani.width  = convert_units(width, from = units, to = "px"),
          ani.height = convert_units(height, from = units, to = "px"),
          clean = TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -343,8 +343,8 @@ ConvexClusteringPostProcess <- function(X,
                                         dendrogram_scale,
                                         npcs){
 
-  n.obs     <- NROW(X)
-  p.var     <- NCOL(X)
+  n         <- NROW(X)
+  p         <- NCOL(X)
   num_edges <- NROW(edge_matrix)
 
   cluster_path <- ISP(sp.path     = t(v_zero_indices),
@@ -353,7 +353,7 @@ ConvexClusteringPostProcess <- function(X,
                       lambda.path = lambda_path,
                       cardE       = num_edges)
 
-  cluster_path[["clust.path"]] <- get_cluster_assignments(edge_matrix, cluster_path$sp.path.inter, n.obs)
+  cluster_path[["clust.path"]] <- get_cluster_assignments(edge_matrix, cluster_path$sp.path.inter, n)
   cluster_path[["clust.path.dups"]] <- duplicated(cluster_path[["clust.path"]], fromList = FALSE)
 
   cvx_dendrogram <- CreateDendrogram(cluster_path, labels, dendrogram_scale)
@@ -361,14 +361,14 @@ ConvexClusteringPostProcess <- function(X,
   X_pca <- stats::prcomp(X, scale. = FALSE, center = FALSE)
   X_pca_rotation <- X_pca$rotation[, seq_len(npcs)]
 
-  U_projected <- crossprod(matrix(cluster_path$u.path.inter, nrow = p.var), X_pca_rotation)
+  U_projected <- crossprod(matrix(cluster_path$u.path.inter, nrow = p), X_pca_rotation)
   colnames(U_projected) <- paste0("PC", seq_len(npcs))
 
   cluster_path_vis <- as_tibble(U_projected) %>%
-                         mutate(Iter = rep(seq_along(cluster_path$clust.path), each = n.obs),
-                                Obs  = rep(seq_len(n.obs), times = length(cluster_path$clust.path)),
-                                Cluster = as.vector(vapply(cluster_path$clust.path, function(x) x$membership, double(n.obs))),
-                                Lambda = rep(cluster_path$lambda.path.inter, each = n.obs),
+                         mutate(Iter = rep(seq_along(cluster_path$clust.path), each = n),
+                                Obs  = rep(seq_len(n), times = length(cluster_path$clust.path)),
+                                Cluster = as.vector(vapply(cluster_path$clust.path, function(x) x$membership, double(n))),
+                                Lambda = rep(cluster_path$lambda.path.inter, each = n),
                                 ObsLabel = rep(labels, times = length(cluster_path$clust.path))) %>%
                          group_by(.data$Iter) %>%
                          mutate(NCluster = n_distinct(.data$Cluster)) %>%

--- a/R/utils.R
+++ b/R/utils.R
@@ -383,10 +383,12 @@ ConvexClusteringPostProcess <- function(X,
 # From ?is.integer:
 is.wholenumber <- function(x, tol = .Machine$double.eps^0.5)  abs(x - round(x)) < tol
 
-is_logical_scalar <- function(x) {is.logical(x) && (length(x) == 1L) && (!is.na(x))}
-is_numeric_scalar <- function(x) {is.numeric(x) && (length(x) == 1L) && (!is.na(x))}
-is_integer_scalar <- function(x) is_numeric_scalar(x) && is.wholenumber(x)
-is_percent_scalar <- function(x) is_numeric_scalar(x) && (x >= 0) && (x <= 1)
+is_logical_scalar  <- function(x) {is.logical(x) && (length(x) == 1L) && (!is.na(x))}
+is_numeric_scalar  <- function(x) {is.numeric(x) && (length(x) == 1L) && (!is.na(x))}
+is_integer_scalar  <- function(x) is_numeric_scalar(x) && is.wholenumber(x)
+is_percent_scalar  <- function(x) is_numeric_scalar(x) && (x >= 0) && (x <= 1)
+is_positive_scalar <- function(x) is_numeric_scalar(x) && (x > 0)
+is_positive_integer_scalar <- function(x) is_integer_scalar(x) && (x > 0)
 
 is_square <- function(x) {is.matrix(x) && (NROW(x) == NCOL(x))}
 

--- a/R/weights.R
+++ b/R/weights.R
@@ -1,30 +1,4 @@
-#' Construct adjacency matrix induced by weights
-#'
-#' @param weights a vector of weights such as returned by \code{SparseWeights}
-#' @param nobs the number of observations being clustered
-#' @param weighted a logical. If \code{FALSE} created unweighted adjacency matrix
-#' determined by support of weight vector. If TRUE create weighted adjacency;
-#' default is FALSE.
-#' @param upper a logical. If \code{TRUE} only return upper triangular of matrix.
-#' If \code{FALSE} return symmetric adjacency
-#' @return adj a sparse adjacency matrix
-#' @keywords internal
-#' @importFrom Matrix Matrix
-#' @importFrom Matrix t
-WeightAdjacency <- function(weights, nobs, weighted = FALSE, upper = TRUE) {
-  adj <- Matrix::Matrix(data = 0, nrow = nobs, ncol = nobs, sparse = TRUE)
-  if (!weighted) {
-    adj[lower.tri(adj, diag = FALSE)] <- as.numeric(weights != 0)
-  } else {
-    adj[lower.tri(adj, diag = FALSE)] <- weights
-  }
-  adj <- Matrix::t(adj)
-  if (!upper) {
-    adj <- adj + Matrix::t(adj)
-  }
-  adj
-}
-
+# Helper types to hold onto weight selection details
 RBFWeights <- function(phi = phi,
                        user_phi = user_phi,
                        dist.method = dist.method,

--- a/src/carp.cpp
+++ b/src/carp.cpp
@@ -3,7 +3,7 @@
 // [[Rcpp::export]]
 Rcpp::List CARPcpp(const Eigen::MatrixXd& X,
                    const Eigen::MatrixXd& D,
-                   double lambda_init, // TODO: Change to gamma_init
+                   double epsilon,
                    double t,
                    const Eigen::VectorXd& weights,
                    double rho   = 1,
@@ -51,9 +51,9 @@ Rcpp::List CARPcpp(const Eigen::MatrixXd& X,
   Eigen::MatrixXd Z = V;
 
   // Regularization level
-  double gamma = lambda_init;              // Working copy
+  double gamma = epsilon;                  // Working copy
   Eigen::VectorXd gamma_path(buffer_size); // Storage (to be returned to R)
-  gamma_path(0) = lambda_init;
+  gamma_path(0) = epsilon;
 
   // Fusions
   Eigen::MatrixXi v_zeros_path(num_edges, buffer_size); // Storage (to be returned to R)

--- a/src/carp.cpp
+++ b/src/carp.cpp
@@ -119,7 +119,7 @@ Rcpp::List CARPcpp(const Eigen::VectorXd& x,
     // TODO- Document this check: what are we trying to do here?
     for(int l = 0; l < num_edges; l++){
       Eigen::VectorXi v_index = IndMat.row(l);
-      if(extract(v_new, v_index).sum() == 0){
+      if(extract(v_new, v_index).cwiseAbs().sum() == 0){
         vZeroIndsnew(l) = 1;
       }
     }

--- a/src/carp.cpp
+++ b/src/carp.cpp
@@ -85,31 +85,11 @@ Rcpp::List CARPcpp(const Eigen::MatrixXd& X,
 
     // V-update
     Eigen::MatrixXd DUZ = DU + Z;
-
-    if(l1){
-      for(Eigen::Index i = 0; i < num_edges; i++){
-        for(Eigen::Index j = 0; j < p; j++){
-          V(i, j) = soft_thresh(DUZ(i, j), gamma / rho * weights(i));
-        }
-      }
-    } else {
-      for(Eigen::Index i = 0; i < num_edges; i++){
-        Eigen::VectorXd DUZ_i = DUZ.row(i);
-        double scale_factor = 1 - gamma * weights(i) / (rho * DUZ_i.norm());
-
-        if(scale_factor > 0){
-          V.row(i) = DUZ_i * scale_factor;
-        } else {
-          V.row(i).setZero();
-        }
-      }
-    }
-
+    MatrixProx(DUZ, V, gamma / rho, weights, l1);
     ClustRVizLogger::debug("V = ") << V;
 
     // Z-update
     Z += DU - V;
-
     ClustRVizLogger::debug("Z = ") << Z;
 
     // Identify cluster fusions (rows of V which have gone to zero)

--- a/src/carp.cpp
+++ b/src/carp.cpp
@@ -1,27 +1,22 @@
 #include "clustRviz.h"
 
 // [[Rcpp::export]]
-Rcpp::List CARPcpp(const Eigen::VectorXd& x,
-                   int n,
-                   int p,
+Rcpp::List CARPcpp(const Eigen::MatrixXd& X,
+                   const Eigen::MatrixXd& D,
                    double lambda_init, // TODO: Change to gamma_init
                    double t,
                    const Eigen::VectorXd& weights,
-                   const Eigen::VectorXd& uinit, // TODO: Change to u_init
-                   const Eigen::VectorXd& vinit, // TODO: Change to v_init
-                   const Eigen::SparseMatrix<double>& premat,
-                   const Eigen::MatrixXi& IndMat,
-                   const Eigen::MatrixXi& EOneIndMat,
-                   const Eigen::MatrixXi& ETwoIndMat,
                    double rho   = 1,
                    int max_iter = 10000,
                    int burn_in  = 50,
                    int keep     = 10,
                    bool l1      = false){
 
+  Eigen::Index n = X.rows();
+  Eigen::Index p = X.cols();
   // Typically, our weights are "sparse" (i.e., mostly zeros) because we
   // drop small weights to achieve performance.
-  Eigen::Index num_edges = EOneIndMat.rows();
+  Eigen::Index num_edges = D.rows();
 
   /// Set-up storage for CARP iterates
 
@@ -32,43 +27,43 @@ Rcpp::List CARPcpp(const Eigen::VectorXd& x,
   // storage objects, so we use 1.5n for now
   Eigen::Index buffer_size = 1.5 * n;
 
-  // Primal variable (corresponds to u in the notation of Chi & Lange (JCGS, 2015))
-  Eigen::VectorXd u_new(n * p);              // Working copies
-  Eigen::VectorXd u_old(n * p);
-  u_new = uinit;
+  // Primal variable
+  Eigen::MatrixXd U = X;
   Eigen::MatrixXd UPath(n * p, buffer_size); // Storage (for values to return to R)
-  UPath.col(0) = uinit;
+  // We cannot directly copy matrices into columns of our return object since
+  // a matrix isn't a vector, so we map the same storage into a vector which we
+  // can then insert into the storage matrix to be returned to R
+  Eigen::Map<Eigen::VectorXd> u_vec = Eigen::Map<Eigen::VectorXd>(U.data(), n * p);
 
-  // 'Split' variable (corresponds to v in the notation of Chi & Lange (JCGS, 2015))
-  Eigen::VectorXd v_new(p * num_edges);              // Working copies
-  Eigen::VectorXd v_old(p * num_edges);
-  v_new = vinit;
+  // 'Split' variable
+  Eigen::MatrixXd V = D * U;
   Eigen::MatrixXd VPath(p * num_edges, buffer_size); // Storage (for values to return to R)
-  VPath.col(0) = vinit;
+  Eigen::Map<Eigen::VectorXd> v_vec = Eigen::Map<Eigen::VectorXd>(V.data(), p * num_edges);
 
-  // (Scaled) dual variable (corresponds to lambda in the notation of Chi and Lange (JCGS, 2015))
-  Eigen::VectorXd z_new(p * num_edges); // Working copy
-  Eigen::VectorXd z_old(p * num_edges); // No storage needed since these aren't of direct interest
-  z_new = v_new;
+  U.transposeInPlace(); // See note on transpositions below
+  UPath.col(0) = u_vec;
+  U.transposeInPlace();
+  V.transposeInPlace();
+  VPath.col(0) = v_vec;
+  V.transposeInPlace();
+
+  // (Scaled) dual variable
+  Eigen::MatrixXd Z = V;
 
   // Regularization level
   double gamma = lambda_init;              // Working copy
   Eigen::VectorXd gamma_path(buffer_size); // Storage (to be returned to R)
   gamma_path(0) = lambda_init;
 
-  // Fusions -- TODO: Confirm the semantics of these objects with JN
-  Eigen::VectorXd vZeroIndsnew = Eigen::VectorXd::Zero(num_edges);          // Working copies
-  Eigen::VectorXd vZeroIndsold(num_edges);                                  // (we begin with no fusions)
-  Eigen::MatrixXd vZeroInds_Path = Eigen::MatrixXd(num_edges, buffer_size); // Storage (to be returned to R)
-  vZeroInds_Path.col(0) = vZeroIndsnew;
+  // Fusions
+  Eigen::MatrixXi v_zeros_path(num_edges, buffer_size); // Storage (to be returned to R)
+  v_zeros_path.col(0).setZero();
 
   /// END Preallocations
 
-  // At each iteration, we need to calculate A^{-1}B_k for some (sparse) A
-  // This is a relatively expensive iteration, but the core cost is a sparse LU
-  // factorization of A which can be amortized over iterations so we pre-compute it here
-  Eigen::SparseLU<Eigen::SparseMatrix<double> > premat_solver;
-  premat_solver.compute(premat);
+  // PreCompute chol(I + rho D^TD) for easy inversions in the U update step
+  Eigen::MatrixXd IDTD = rho * D.transpose() * D + Eigen::MatrixXd::Identity(n, n);
+  Eigen::LLT<Eigen::MatrixXd> u_step_solver; u_step_solver.compute(IDTD);
 
   // Book-keeping variables
   // Number of iterations stored, total iteration count, number of fusions
@@ -80,57 +75,57 @@ Rcpp::List CARPcpp(const Eigen::VectorXd& x,
   while( (iter < max_iter) & (nzeros_new < num_edges) ){
     ClustRVizLogger::info("Beginning iteration k = ") << iter + 1;
     ClustRVizLogger::debug("gamma = ") << gamma;
-    // Begin iteration - move updated values to "_old" values
-    //
-    // TODO -- Confirm that these use "move semantics" to avoid full copies
-    u_old        = u_new;
-    v_old        = v_new;
-    z_old        = z_new;
-    vZeroIndsold = vZeroIndsnew;
-    nzeros_old   = nzeros_new;
+
+    nzeros_old = nzeros_new;
 
     // U-update
-    // TODO - Document what is happening here
-    Eigen::VectorXd solver_input = DtMatOpv2(rho * v_old - z_old, n, p, IndMat, EOneIndMat, ETwoIndMat);
-    solver_input += x;
-    solver_input /= rho;
-    u_new = premat_solver.solve(solver_input);
-
-    ClustRVizLogger::debug("u = ") << u_new;
+    U = u_step_solver.solve(X + rho * D.transpose() * (V - Z));
+    Eigen::MatrixXd DU = D * U;
+    ClustRVizLogger::debug("U = ") << U;
 
     // V-update
-    // TODO - Document what is happening here
-    Eigen::VectorXd prox_argument = DMatOpv2(u_new, p, IndMat, EOneIndMat, ETwoIndMat) + (1/rho)*z_old;
+    Eigen::MatrixXd DUZ = DU + Z;
 
     if(l1){
-      v_new = ProxL1(prox_argument, p, (1/rho) * gamma, weights);
+      for(Eigen::Index i = 0; i < num_edges; i++){
+        for(Eigen::Index j = 0; j < p; j++){
+          V(i, j) = soft_thresh(DUZ(i, j), gamma / rho * weights(i));
+        }
+      }
     } else {
-      v_new = ProxL2(prox_argument, p, (1/rho) * weights * gamma, IndMat);
-    }
+      for(Eigen::Index i = 0; i < num_edges; i++){
+        Eigen::VectorXd DUZ_i = DUZ.row(i);
+        double scale_factor = 1 - gamma * weights(i) / (rho * DUZ_i.norm());
 
-    ClustRVizLogger::debug("v = ") << v_new;
-
-    // Z-update
-    // TODO - Document what is happening here
-    z_new = z_old + rho*(DMatOpv2(u_new, p, IndMat, EOneIndMat, ETwoIndMat) - v_new);
-
-    ClustRVizLogger::debug("z = ") << z_new;
-
-    // TODO- Document this check: what are we trying to do here?
-    for(int l = 0; l < num_edges; l++){
-      Eigen::VectorXi v_index = IndMat.row(l);
-      if(extract(v_new, v_index).cwiseAbs().sum() == 0){
-        vZeroIndsnew(l) = 1;
+        if(scale_factor > 0){
+          V.row(i) = DUZ_i * scale_factor;
+        } else {
+          V.row(i).setZero();
+        }
       }
     }
-    nzeros_new = vZeroIndsnew.sum();
+
+    ClustRVizLogger::debug("V = ") << V;
+
+    // Z-update
+    Z += DU - V;
+
+    ClustRVizLogger::debug("Z = ") << Z;
+
+    // Identify cluster fusions (rows of V which have gone to zero)
+    Eigen::VectorXd v_norms = V.rowwise().squaredNorm();
+    Eigen::ArrayXi  v_zeros(num_edges);
+
+    for(Eigen::Index i = 0; i < num_edges; i++){
+      v_zeros(i) = v_norms(i) == 0;
+    }
+    nzeros_new = v_zeros.sum();
 
     ClustRVizLogger::debug("Number of fusions identified ") << nzeros_new;
 
     // If we have seen a fusion or are otherwise interested in keeping this iteration,
     // add values to our storage buffers
     if( (nzeros_new != nzeros_old) | (iter % keep == 0) ) {
-
       // Before we can store values, we need to make sure we have enough buffer space
       if(path_iter >= buffer_size){
         ClustRVizLogger::info("Resizing storage from ") << buffer_size << " to " << 2 * buffer_size << " iterations.";
@@ -138,14 +133,29 @@ Rcpp::List CARPcpp(const Eigen::VectorXd& x,
         UPath.conservativeResize(UPath.rows(), buffer_size);
         VPath.conservativeResize(VPath.rows(), buffer_size);
         gamma_path.conservativeResize(buffer_size);
-        vZeroInds_Path.conservativeResize(vZeroInds_Path.rows(), buffer_size);
+        v_zeros_path.conservativeResize(v_zeros_path.rows(), buffer_size);
       }
 
       // Store values
-      UPath.col(path_iter)          = u_new;
-      VPath.col(path_iter)          = v_new;
+
+      // FIXME -- The post-processing code assumes output in the form of
+      //          Chi and Lange (JCGS, 2015) which more or less is equivalent
+      //          to vec(U^T) and vec(V^T) instead of what we're using internally
+      //          here.
+      //
+      //          It should be re-written, but until it is, we can achieve the
+      //          same result by transposing and un-transposing the data internally
+      //          before copying it to our storage buffers
+      //
+      //          Obviously, this burns some cycles so it would be better to avoid this
+      U.transposeInPlace(); V.transposeInPlace();
+
+      UPath.col(path_iter)          = u_vec;
+      VPath.col(path_iter)          = v_vec;
       gamma_path(path_iter)         = gamma;
-      vZeroInds_Path.col(path_iter) = vZeroIndsnew;
+      v_zeros_path.col(path_iter)   = v_zeros;
+
+      U.transposeInPlace(); V.transposeInPlace();
 
       path_iter++;
     }
@@ -170,11 +180,11 @@ Rcpp::List CARPcpp(const Eigen::VectorXd& x,
   UPath.conservativeResize(UPath.rows(), path_iter);
   VPath.conservativeResize(VPath.rows(), path_iter);
   gamma_path.conservativeResize(path_iter);
-  vZeroInds_Path.conservativeResize(vZeroInds_Path.rows(), path_iter);
+  v_zeros_path.conservativeResize(v_zeros_path.rows(), path_iter);
 
   // Wrap up our results and pass them to R
   return Rcpp::List::create(Rcpp::Named("u.path")      = UPath,
                             Rcpp::Named("v.path")      = VPath,
-                            Rcpp::Named("v.zero.inds") = vZeroInds_Path,
-                            Rcpp::Named("lambda.path")  = gamma_path); // TODO - Change lambda -> gamma in R code
+                            Rcpp::Named("v.zero.inds") = v_zeros_path,
+                            Rcpp::Named("lambda.path") = gamma_path); // TODO - Change lambda -> gamma in R code
 }

--- a/src/carp_viz.cpp
+++ b/src/carp_viz.cpp
@@ -146,7 +146,7 @@ Rcpp::List CARP_VIZcpp(const Eigen::VectorXd& x,
       // TODO- Document this check: what are we trying to do here?
       for(int l = 0; l < num_edges; l++){
         Eigen::VectorXi v_index = IndMat.row(l);
-        if(extract(v_new, v_index).sum() == 0){
+        if(extract(v_new, v_index).cwiseAbs().sum() == 0){
           vZeroIndsnew(l) = 1;
         }
       }

--- a/src/carp_viz.cpp
+++ b/src/carp_viz.cpp
@@ -117,26 +117,7 @@ Rcpp::List CARP_VIZcpp(const Eigen::MatrixXd& X,
 
       // V-update
       Eigen::MatrixXd DUZ = DU + Z_old;
-
-      if(l1){
-        for(Eigen::Index i = 0; i < num_edges; i++){
-          for(Eigen::Index j = 0; j < p; j++){
-            V(i, j) = soft_thresh(DUZ(i, j), gamma / rho * weights(i));
-          }
-        }
-      } else {
-        for(Eigen::Index i = 0; i < num_edges; i++){
-          Eigen::VectorXd DUZ_i = DUZ.row(i);
-          double scale_factor = 1 - gamma * weights(i) / (rho * DUZ_i.norm());
-
-          if(scale_factor > 0){
-            V.row(i) = DUZ_i * scale_factor;
-          } else {
-            V.row(i).setZero();
-          }
-        }
-      }
-
+      MatrixProx(DUZ, V, gamma / rho, weights, l1);
       ClustRVizLogger::debug("V = ") << V;
 
       // Z-update

--- a/src/cbass.cpp
+++ b/src/cbass.cpp
@@ -1,35 +1,26 @@
 #include "clustRviz.h"
 
 // [[Rcpp::export]]
-Rcpp::List CBASScpp(const Eigen::VectorXd& x,
-                    int n,
-                    int p,
+Rcpp::List CBASScpp(const Eigen::MatrixXd& X,
+                    const Eigen::MatrixXd& D_row,
+                    const Eigen::MatrixXd& D_col,
                     double lambda_init, // TODO: Change to gamma_init
                     double t,
                     const Eigen::VectorXd& weights_row,
                     const Eigen::VectorXd& weights_col,
-                    const Eigen::VectorXd& uinit_row, // TODO: Change to u_init_row
-                    const Eigen::VectorXd& uinit_col, // TODO: Change to u_init_col
-                    const Eigen::VectorXd& vinit_row, // TODO: Change to v_init_row
-                    const Eigen::VectorXd& vinit_col, // TODO: Change to v_init_col
-                    const Eigen::SparseMatrix<double>& premat_row,
-                    const Eigen::SparseMatrix<double>& premat_col,
-                    const Eigen::MatrixXi& IndMat_row,
-                    const Eigen::MatrixXi& IndMat_col,
-                    const Eigen::MatrixXi& EOneIndMat_row,
-                    const Eigen::MatrixXi& EOneIndMat_col,
-                    const Eigen::MatrixXi& ETwoIndMat_row,
-                    const Eigen::MatrixXi& ETwoIndMat_col,
                     double rho   = 1,
                     int max_iter = 1e4,
                     int burn_in  = 50,
                     int keep     = 10,
                     bool l1      = false){
 
+  Eigen::Index n = X.rows();
+  Eigen::Index p = X.cols();
+
   // Typically, our weights are "sparse" (i.e., mostly zeros) because we
   // drop small weights to achieve performance.
-  Eigen::Index num_edges_row = EOneIndMat_row.rows();
-  Eigen::Index num_edges_col = EOneIndMat_col.rows();
+  Eigen::Index num_row_edges = D_row.rows();
+  Eigen::Index num_col_edges = D_col.cols();
 
   /// Set-up storage for CBASS iterates
 
@@ -41,82 +32,63 @@ Rcpp::List CBASScpp(const Eigen::VectorXd& x,
   Eigen::Index buffer_size = 1.5 * (n + p);
 
   // Primal variable
-  Eigen::VectorXd u_new(n * p);              // Working copies
-  Eigen::VectorXd u_old(n * p);
-  u_new = x;
+  Eigen::MatrixXd U = X;
   Eigen::MatrixXd UPath(n * p, buffer_size); // Storage (for values to return to R)
-  UPath.col(0) = uinit_col;
+  // We cannot directly copy matrices into columns of our return object since
+  // a matrix isn't a vector, so we map the same storage into a vector which we
+  // can then insert into the storage matrix to be returned to R
+  Eigen::Map<Eigen::VectorXd> u_vec = Eigen::Map<Eigen::VectorXd>(U.data(), n * p);
 
-  // 'Split' variable for row fusions
-  Eigen::VectorXd v_new_row(n * num_edges_row);              // Working copies
-  Eigen::VectorXd v_old_row(n * num_edges_row);
-  v_new_row = vinit_row;
-  Eigen::MatrixXd VPath_row(n * num_edges_row, buffer_size); // Storage (for values to return to R)
-  VPath_row.col(0) = vinit_row;
+  // 'Split' variable for row ADMM
+  Eigen::MatrixXd V_row = D_row * X;
+  Eigen::MatrixXd V_rowPath(p * num_row_edges, buffer_size); // Storage (for values to return to R)
+  Eigen::Map<Eigen::VectorXd> v_row_vec = Eigen::Map<Eigen::VectorXd>(V_row.data(), p * num_row_edges);
 
-  // 'Split' variable for column fusions
-  Eigen::VectorXd v_new_col(p * num_edges_col);              // Working copies
-  Eigen::VectorXd v_old_col(p * num_edges_col);
-  v_new_col = vinit_col;
-  Eigen::MatrixXd VPath_col(p * num_edges_col, buffer_size); // Storage (for values to return to R)
-  VPath_col.col(0) = vinit_col;
+  // (Scaled) dual variable for row ADMM
+  Eigen::MatrixXd Z_row = V_row;
 
-  // (Scaled) dual variable for row fusions
-  Eigen::VectorXd z_new_row(p * num_edges_row);
-  Eigen::VectorXd z_old_row(p * num_edges_row);
-  z_new_row = v_new_row;
+  // 'Split' variable for column ADMM
+  Eigen::MatrixXd V_col = D_col.transpose() * X.transpose();
+  Eigen::MatrixXd V_colPath(n * num_col_edges, buffer_size); // Storage (for values to return to R)
+  Eigen::Map<Eigen::VectorXd> v_col_vec = Eigen::Map<Eigen::VectorXd>(V_col.data(), n * num_col_edges);
 
-  // (Scaled) dual variable for column fusions
-  Eigen::VectorXd z_new_col(p * num_edges_col);
-  Eigen::VectorXd z_old_col(p * num_edges_col);
-  z_new_col = v_new_col;
+  // (Scaled) dual variable for row ADMM
+  Eigen::MatrixXd Z_col = V_col;
+
+  U.transposeInPlace(); // See note on transpositions below
+  UPath.col(0) = u_vec;
+  U.transposeInPlace();
+  V_row.transposeInPlace();
+  V_rowPath.col(0) = v_row_vec;
+  V_row.transposeInPlace();
+  V_col.transposeInPlace();
+  V_colPath.col(0) = v_col_vec;
+  V_col.transposeInPlace();
 
   // Regularization level
   double gamma = lambda_init;              // Working copy
   Eigen::VectorXd gamma_path(buffer_size); // Storage (to be returned to R)
   gamma_path(0) = lambda_init;
 
-  // Row Fusions -- TODO: Confirm the semantics of these objects with JN
-  Eigen::VectorXd vZeroIndsnew_row = Eigen::VectorXd::Zero(num_edges_row);         // Working copies
-  Eigen::VectorXd vZeroIndsold_row(num_edges_row);                                 // (we begin with no fusions)
-  Eigen::MatrixXd vZeroIndsPath_row = Eigen::MatrixXd(num_edges_row, buffer_size); // Storage (to be returned to R)
-  vZeroIndsPath_row.col(0) = vZeroIndsnew_row;
-
-  // Column Fusions -- TODO: Confirm the semantics of these objects with JN
-  Eigen::VectorXd vZeroIndsnew_col = Eigen::VectorXd::Zero(num_edges_col);         // Working copies
-  Eigen::VectorXd vZeroIndsold_col(num_edges_col);                                 // (we begin with no fusions)
-  Eigen::MatrixXd vZeroIndsPath_col = Eigen::MatrixXd(num_edges_col, buffer_size); // Storage (to be returned to R)
-  vZeroIndsPath_col.col(0) = vZeroIndsnew_col;
-
-  // The COBRA algorithm for Convex Bi-Clustering (on which CBASS is based)
-  // introduces extra variables Y, P, Q which are necessary to keep the row-
-  // and column-fusions appropriately coupled.
-  //
-  // See Chi, Allen, Baraniuk (2017) for details
-  //
-  // Since we are working in "vec" form, instead of matrix form, we use the
-  // `restride()` function to re-organize a vector from an ordering appropriate
-  // for the row-based steps to an ordering for the column-based steps and vice versa
-  //
-  // Note that we use a different notational convention here (capital P vs lower-case p)
-  // to distinguish this "p" from the "p" that gives the problem dimension
-  //
-  // Y is not carried forward from one iteration to the next, so we declare it in-loop below
-  Eigen::VectorXd P_new = Eigen::VectorXd::Zero(n * p);
-  Eigen::VectorXd P_old(n * p);
-  Eigen::VectorXd Q_new = Eigen::VectorXd::Zero(n * p);
-  Eigen::VectorXd Q_old(n * p);
+  // Fusions
+  Eigen::MatrixXi v_row_zeros_path(num_row_edges, buffer_size); // Storage (to be returned to R)
+  v_row_zeros_path.col(0).setZero();
+  Eigen::MatrixXi v_col_zeros_path(num_col_edges, buffer_size); // Storage (to be returned to R)
+  v_col_zeros_path.col(0).setZero();
 
   /// END Preallocations
 
-  // At each iteration, we need to calculate A^{-1}B_k for some (sparse) A [one for rows and one for cols]
-  // This is a relatively expensive iteration, but the core cost is a sparse LU
-  // factorization of A which can be amortized over iterations so we pre-compute them here
-  Eigen::SparseLU<Eigen::SparseMatrix<double> > premat_solver_row;
-  premat_solver_row.compute(premat_row);
+  // PreCompute chol(I_n + rho D_row^T D_row) and chol(I_p + rho D_col D_col^T) for easy inversions in the ADMM primal update steps
+  Eigen::MatrixXd IDTD_row = rho * D_row.transpose() * D_row + Eigen::MatrixXd::Identity(n, n);
+  Eigen::LLT<Eigen::MatrixXd> row_primal_solver; row_primal_solver.compute(IDTD_row);
 
-  Eigen::SparseLU<Eigen::SparseMatrix<double> > premat_solver_col;
-  premat_solver_col.compute(premat_col);
+  Eigen::MatrixXd IDDT_col = rho * D_col * D_col.transpose()  + Eigen::MatrixXd::Identity(p, p);
+  Eigen::LLT<Eigen::MatrixXd> col_primal_solver; col_primal_solver.compute(IDDT_col);
+
+  // The DLPA (on which CBASS is based) adds two auxiliary variables -- P & Q --
+  // with the same dimensions as the optimization variable, initialized to zero
+  Eigen::MatrixXd P = Eigen::MatrixXd::Zero(n, p);
+  Eigen::MatrixXd Q = Eigen::MatrixXd::Zero(n, p);
 
   // Book-keeping variables
   // Number of iterations stored, total iteration count, number of column fusions, number of row fusions
@@ -127,99 +99,70 @@ Rcpp::List CBASScpp(const Eigen::VectorXd& x,
   Eigen::Index nzeros_old_col = 0;
   Eigen::Index nzeros_new_col = 0;
 
-  while( ((nzeros_new_row < num_edges_row) | (nzeros_new_col < num_edges_col)) & (iter < max_iter)){
+  while( ((nzeros_new_row < num_row_edges) | (nzeros_new_col < num_col_edges)) & (iter < max_iter) ){
     ClustRVizLogger::info("Beginning iteration k = ") << iter + 1;
     ClustRVizLogger::debug("gamma = ") << gamma;
-    // Begin iteration - move updated values to "_old" values
-    //
-    // TODO -- Do this as a swap and avoid full copies if possible
-    u_old = u_new;                       // Primal
-    v_old_row = v_new_row;               // Split
-    v_old_col = v_new_col;
-    z_old_row = z_new_row;               // Dual
-    z_old_col = z_new_col;
-    nzeros_old_row = nzeros_new_row;     // Fusion counts
-    nzeros_old_col = nzeros_new_col;
-    vZeroIndsold_row = vZeroIndsnew_row; // Fusion indices
-    vZeroIndsold_col = vZeroIndsnew_col;
 
-    P_old = P_new;
-    Q_old = Q_new;
-    Eigen::VectorXd P_old_t = restride(P_old, p);
-    Eigen::VectorXd u_old_t = restride(u_old, p);
+    nzeros_old_row = nzeros_new_row; // Update fusion counts
+    nzeros_old_col = nzeros_new_col;
 
     /// Row-fusion iterations
-    // U-update
-    Eigen::VectorXd solver_input_row = DtMatOpv2(rho * v_old_row - z_old_row, p, n, IndMat_row, EOneIndMat_row, ETwoIndMat_row);
-    solver_input_row += P_old_t + u_old_t;
-    solver_input_row /= rho;
-    Eigen::VectorXd Y_t = premat_solver_row.solve(solver_input_row);
+    // Primal Update
+    Eigen::MatrixXd T = row_primal_solver.solve(U + P + rho * D_row.transpose() * (V_row - Z_row));
+    Eigen::MatrixXd DT = D_row * T;
+    ClustRVizLogger::debug("T = ") << T;
 
-    ClustRVizLogger::debug("y^T = ") << Y_t;
+    // Copy Update
+    Eigen::MatrixXd DTZ = DT + Z_row;
+    MatrixProx(DTZ, V_row, gamma / rho, weights_row, l1);
+    ClustRVizLogger::debug("V_row = ") << V_row;
 
-    // V-update
-    Eigen::VectorXd prox_argument_row = DMatOpv2(Y_t,n, IndMat_row, EOneIndMat_row, ETwoIndMat_row) + (1/rho)*z_old_row;
-    if(l1){
-      v_new_row = ProxL1(prox_argument_row, n, (1/rho) * gamma, weights_row);
-    } else {
-      v_new_row = ProxL2(prox_argument_row, n, (1/rho) * weights_row * gamma, IndMat_row);
-    }
-
-    ClustRVizLogger::debug("v_row = ") << v_new_row;
-
-    // Z-update
-    z_new_row = z_old_row + rho*(DMatOpv2(Y_t, n, IndMat_row, EOneIndMat_row, ETwoIndMat_row) - v_new_row);
-
-    ClustRVizLogger::debug("z_row = ") << z_new_row;
+    // Dual Update
+    Z_row += DT - V_row;
+    ClustRVizLogger::debug("Z_row = ") << Z_row;
     /// END Row-fusion iterations
 
-    Eigen::VectorXd Y = restride(Y_t, n);
-    P_new = u_old + P_old - Y;
+    P += U - T;
+    Eigen::MatrixXd TQT = T + Q; TQT.transposeInPlace();
 
     /// Column-fusion iterations
-    // U-update
-    Eigen::VectorXd solver_input_col = DtMatOpv2(rho * v_old_col - z_old_col, n, p, IndMat_col, EOneIndMat_col, ETwoIndMat_col);
-    solver_input_col += Y + Q_old;
-    solver_input_col /= rho;
-    u_new = premat_solver_col.solve(solver_input_col);
+    // Primal Update
+    Eigen::MatrixXd S = col_primal_solver.solve(TQT + rho * D_col * (V_col - Z_col));
+    Eigen::MatrixXd DTS = D_col.transpose() * S;
+    ClustRVizLogger::debug("S = ") << S;
 
-    ClustRVizLogger::debug("u = ") << u_new;
+    // Copy Update
+    Eigen::MatrixXd DTSZ = DTS + Z_col;
+    MatrixProx(DTSZ, V_col, gamma / rho, weights_col, l1);
+    ClustRVizLogger::debug("V_col = ") << V_col;
 
-    // V-update
-    Eigen::VectorXd prox_argument_col = DMatOpv2(u_new, p, IndMat_col, EOneIndMat_col, ETwoIndMat_col) + (1/rho)*z_old_col;
-    if(l1){
-      v_new_col = ProxL1(prox_argument_col, p, (1/rho) * gamma, weights_col);
-    } else {
-      v_new_col = ProxL2(prox_argument_col, p, (1/rho) * weights_col * gamma, IndMat_col);
-    }
-
-    ClustRVizLogger::debug("v_col = ") << v_new_col;
-
-    // Z-update
-    z_new_col = z_old_col + rho*(DMatOpv2(u_new, p, IndMat_col, EOneIndMat_col, ETwoIndMat_col)-v_new_col);
-
-    ClustRVizLogger::debug("z_col = ") << z_new_col;
+    // Dual Update
+    Z_col += DTS - V_col;
+    ClustRVizLogger::debug("Z_col = ") << Z_col;
     /// END Column-fusion iterations
 
-    Q_new = Y + Q_old - u_new;
+    U = S.transpose();
+    Q += T - U;
 
-    // Count number of row fusions
-    for(int l = 0; l < num_edges_row; l++){
-      Eigen::VectorXi v_index_row = IndMat_row.row(l);
-      if(extract(v_new_row, v_index_row).cwiseAbs().sum() == 0){
-        vZeroIndsnew_row(l) = 1;
-      }
-    }
-    nzeros_new_row = vZeroIndsnew_row.sum();
+    // Identify row fusions (rows of V_row which have gone to zero)
+    Eigen::VectorXd v_row_norms = V_row.rowwise().squaredNorm();
+    Eigen::ArrayXi  v_row_zeros(num_row_edges);
 
-    // Count number of column fusions
-    for(int l = 0; l < num_edges_col; l++){
-      Eigen::VectorXi v_index_col = IndMat_col.row(l);
-      if(extract(v_new_col, v_index_col).cwiseAbs().sum() == 0){
-        vZeroIndsnew_col(l) = 1;
-      }
+    for(Eigen::Index i = 0; i < num_row_edges; i++){
+      v_row_zeros(i) = v_row_norms(i) == 0;
     }
-    nzeros_new_col = vZeroIndsnew_col.sum();
+    nzeros_new_row = v_row_zeros.sum();
+
+    // Identify column fusions (rows of V_col which have gone to zero)
+    // Remember, V_col and Z_col are internal to the "transposed prox" sub-problem
+    // so everything is reversed of what we'd expect
+    Eigen::VectorXd v_col_norms = V_col.rowwise().squaredNorm();
+    Eigen::ArrayXi  v_col_zeros(num_col_edges);
+
+    for(Eigen::Index i = 0; i < num_col_edges; i++){
+      v_col_zeros(i) = v_col_norms(i) == 0;
+    }
+    nzeros_new_col = v_col_zeros.sum();
 
     ClustRVizLogger::debug("Number of row fusions identified ") << nzeros_new_row;
     ClustRVizLogger::debug("Number of column fusions identified ") << nzeros_new_col;
@@ -232,20 +175,33 @@ Rcpp::List CBASScpp(const Eigen::VectorXd& x,
         ClustRVizLogger::info("Resizing storage from ") << buffer_size << " to " << 2 * buffer_size << " iterations.";
         buffer_size *= 2; // Double our buffer sizes
         UPath.conservativeResize(UPath.rows(), buffer_size);
-        VPath_row.conservativeResize(VPath_row.rows(), buffer_size);
-        VPath_col.conservativeResize(VPath_col.rows(), buffer_size);
+        V_rowPath.conservativeResize(V_rowPath.rows(), buffer_size);
+        V_colPath.conservativeResize(V_colPath.rows(), buffer_size);
         gamma_path.conservativeResize(buffer_size);
-        vZeroIndsPath_row.conservativeResize(vZeroIndsPath_row.rows(), buffer_size);
-        vZeroIndsPath_col.conservativeResize(vZeroIndsPath_col.rows(), buffer_size);
+        v_row_zeros_path.conservativeResize(v_row_zeros_path.rows(), buffer_size);
+        v_col_zeros_path.conservativeResize(v_col_zeros_path.rows(), buffer_size);
       }
 
       // Store values
-      UPath.col(path_iter)             = u_new;
-      VPath_row.col(path_iter)         = v_new_row;
-      VPath_col.col(path_iter)         = v_new_col;
-      gamma_path(path_iter)            = gamma;
-      vZeroIndsPath_row.col(path_iter) = vZeroIndsnew_row;
-      vZeroIndsPath_col.col(path_iter) = vZeroIndsnew_col;
+      //
+      // FIXME -- The post-processing code assumes output in the form of
+      //          Chi, Allen, Baraniuk (Biometrics '17) which more or less is equivalent
+      //          to vec(U^T) and vec(V^T) instead of what we're using internally
+      //          here.
+      //
+      //          It should be re-written, but until it is, we can achieve the
+      //          same result by transposing and un-transposing the data internally
+      //          before copying it to our storage buffers
+      //
+      //          Obviously, this burns some cycles so it would be better to avoid this
+      U.transposeInPlace(); V_row.transposeInPlace(); V_col.transposeInPlace();
+      UPath.col(path_iter)            = u_vec;
+      V_rowPath.col(path_iter)        = v_row_vec;
+      V_colPath.col(path_iter)        = v_col_vec;
+      gamma_path(path_iter)           = gamma;
+      v_row_zeros_path.col(path_iter) = v_row_zeros;
+      v_col_zeros_path.col(path_iter) = v_col_zeros;
+      U.transposeInPlace(); V_row.transposeInPlace(); V_col.transposeInPlace();
 
       path_iter++;
     }
@@ -268,17 +224,17 @@ Rcpp::List CBASScpp(const Eigen::VectorXd& x,
   //
   // See explanatory comment in carp_viz.cpp
   UPath.conservativeResize(UPath.rows(), path_iter);
-  VPath_row.conservativeResize(VPath_row.rows(), path_iter);
-  VPath_col.conservativeResize(VPath_col.rows(), path_iter);
+  V_rowPath.conservativeResize(V_rowPath.rows(), path_iter);
+  V_colPath.conservativeResize(V_colPath.rows(), path_iter);
   gamma_path.conservativeResize(path_iter);
-  vZeroIndsPath_row.conservativeResize(vZeroIndsPath_row.rows(), path_iter);
-  vZeroIndsPath_col.conservativeResize(vZeroIndsPath_col.rows(), path_iter);
+  v_row_zeros_path.conservativeResize(v_row_zeros_path.rows(), path_iter);
+  v_col_zeros_path.conservativeResize(v_col_zeros_path.rows(), path_iter);
 
   // Wrap up our results and pass them to R
   return Rcpp::List::create(Rcpp::Named("u.path")          = UPath,
-                            Rcpp::Named("v.row.path")      = VPath_row,
-                            Rcpp::Named("v.col.path")      = VPath_col,
-                            Rcpp::Named("v.row.zero.inds") = vZeroIndsPath_row,
-                            Rcpp::Named("v.col.zero.inds") = vZeroIndsPath_col,
-                            Rcpp::Named("lambda.path")      = gamma_path); // TODO - Change lambda -> gamma in R code
+                            Rcpp::Named("v.row.path")      = V_rowPath,
+                            Rcpp::Named("v.col.path")      = V_colPath,
+                            Rcpp::Named("v.row.zero.inds") = v_row_zeros_path,
+                            Rcpp::Named("v.col.zero.inds") = v_col_zeros_path,
+                            Rcpp::Named("lambda.path")     = gamma_path); // TODO - Change lambda -> gamma in R code
 }

--- a/src/cbass.cpp
+++ b/src/cbass.cpp
@@ -206,7 +206,7 @@ Rcpp::List CBASScpp(const Eigen::VectorXd& x,
     // Count number of row fusions
     for(int l = 0; l < num_edges_row; l++){
       Eigen::VectorXi v_index_row = IndMat_row.row(l);
-      if(extract(v_new_row, v_index_row).sum() == 0){
+      if(extract(v_new_row, v_index_row).cwiseAbs().sum() == 0){
         vZeroIndsnew_row(l) = 1;
       }
     }
@@ -215,7 +215,7 @@ Rcpp::List CBASScpp(const Eigen::VectorXd& x,
     // Count number of column fusions
     for(int l = 0; l < num_edges_col; l++){
       Eigen::VectorXi v_index_col = IndMat_col.row(l);
-      if(extract(v_new_col, v_index_col).sum() == 0){
+      if(extract(v_new_col, v_index_col).cwiseAbs().sum() == 0){
         vZeroIndsnew_col(l) = 1;
       }
     }

--- a/src/cbass.cpp
+++ b/src/cbass.cpp
@@ -4,7 +4,7 @@
 Rcpp::List CBASScpp(const Eigen::MatrixXd& X,
                     const Eigen::MatrixXd& D_row,
                     const Eigen::MatrixXd& D_col,
-                    double lambda_init, // TODO: Change to gamma_init
+                    double epsilon,
                     double t,
                     const Eigen::VectorXd& weights_row,
                     const Eigen::VectorXd& weights_col,
@@ -66,9 +66,9 @@ Rcpp::List CBASScpp(const Eigen::MatrixXd& X,
   V_col.transposeInPlace();
 
   // Regularization level
-  double gamma = lambda_init;              // Working copy
+  double gamma = epsilon;                  // Working copy
   Eigen::VectorXd gamma_path(buffer_size); // Storage (to be returned to R)
-  gamma_path(0) = lambda_init;
+  gamma_path(0) = epsilon;
 
   // Fusions
   Eigen::MatrixXi v_row_zeros_path(num_row_edges, buffer_size); // Storage (to be returned to R)

--- a/src/cbass_viz.cpp
+++ b/src/cbass_viz.cpp
@@ -231,7 +231,7 @@ Rcpp::List CBASS_VIZcpp(const Eigen::VectorXd& x,
       // Count number of row fusions
       for(int l = 0; l < num_edges_row; l++){
         Eigen::VectorXi v_index_row = IndMat_row.row(l);
-        if(extract(v_new_row, v_index_row).sum() == 0){
+        if(extract(v_new_row, v_index_row).cwiseAbs().sum() == 0){
           vZeroIndsnew_row(l) = 1;
         }
       }
@@ -240,7 +240,7 @@ Rcpp::List CBASS_VIZcpp(const Eigen::VectorXd& x,
       // Count number of column fusions
       for(int l = 0; l < num_edges_col; l++){
         Eigen::VectorXi v_index_col = IndMat_col.row(l);
-        if(extract(v_new_col, v_index_col).sum() == 0){
+        if(extract(v_new_col, v_index_col).cwiseAbs().sum() == 0){
           vZeroIndsnew_col(l) = 1;
         }
       }

--- a/src/clustRviz.h
+++ b/src/clustRviz.h
@@ -39,4 +39,10 @@ Eigen::VectorXd ProxL2(const Eigen::VectorXd&, int,
                        const Eigen::VectorXd&, const Eigen::MatrixXi&);
 Eigen::VectorXd ProxL1(const Eigen::VectorXd&, int, double,
                        const Eigen::VectorXd& weights);
-double soft_thresh(double, double);
+
+// Prototypes - utils.cpp
+void MatrixProx(const Eigen::MatrixXd&,
+                Eigen::MatrixXd&,
+                double,
+                const Eigen::VectorXd&,
+                bool);

--- a/src/clustRviz.h
+++ b/src/clustRviz.h
@@ -5,19 +5,6 @@
 
 #define CLUSTRVIZ_CHECK_USER_INTERRUPT_RATE 50
 
-// From https://stackoverflow.com/a/26268017
-template <typename T_full, typename T_ind>
-T_full extract(const T_full& full, const T_ind& ind){
-  Eigen::Index num_indices = ind.innerSize();
-  T_full target(num_indices);
-
-  for(Eigen::Index i = 0; i < num_indices; i++){
-    target[i] = full[ind[i]];
-  }
-
-  return target;
-}
-
 // Helper to determine if STL set contains an element
 //
 // In general, this is not efficient because one wants to do something
@@ -27,18 +14,6 @@ bool contains(const std::set<T>& container, T element){
   typename std::set<T>::const_iterator it = container.find(element);
   return it != container.end();
 }
-
-// Prototypes - Eigen implementations
-Eigen::VectorXd restride(const Eigen::VectorXd&, Eigen::Index);
-Eigen::VectorXd DMatOpv2(const Eigen::VectorXd&, int, const Eigen::MatrixXi&,
-                         const Eigen::MatrixXi&, const Eigen::MatrixXi&);
-Eigen::VectorXd DtMatOpv2(const Eigen::VectorXd&, int, int,
-                          const Eigen::MatrixXi&, const Eigen::MatrixXi&,
-                          const Eigen::MatrixXi&);
-Eigen::VectorXd ProxL2(const Eigen::VectorXd&, int,
-                       const Eigen::VectorXd&, const Eigen::MatrixXi&);
-Eigen::VectorXd ProxL1(const Eigen::VectorXd&, int, double,
-                       const Eigen::VectorXd& weights);
 
 // Prototypes - utils.cpp
 void MatrixProx(const Eigen::MatrixXd&,

--- a/src/clustRviz.h
+++ b/src/clustRviz.h
@@ -39,4 +39,4 @@ Eigen::VectorXd ProxL2(const Eigen::VectorXd&, int,
                        const Eigen::VectorXd&, const Eigen::MatrixXi&);
 Eigen::VectorXd ProxL1(const Eigen::VectorXd&, int, double,
                        const Eigen::VectorXd& weights);
-
+double soft_thresh(double, double);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,78 +1,5 @@
 #include "clustRviz.h"
 
-// Take a vector of length n * k and re-order it as
-// x(0), x(k), x(2*k), x(n*k), x(1), x(k + 1), x(2*k + 1), etc.
-Eigen::VectorXd restride(const Eigen::VectorXd& x,
-                         Eigen::Index k){
-  Eigen::VectorXd ret(x.size());
-
-  Eigen::Index len = x.size() / k;
-
-  if(len * k != x.size()){
-    Rcpp::stop("k does not divide the number of elements of x!");
-  }
-
-  // TODO: Optimize this!
-  for(Eigen::Index j = 0; j < k; j++){
-    for(Eigen::Index i = 0; i < len; i++){
-      ret(i + j * len) = x(j + i * k);
-    }
-  }
-
-  return ret;
-}
-
-// TODO - Document me!
-Eigen::VectorXd DMatOpv2(const Eigen::VectorXd& u,
-                         int p,
-                         const Eigen::MatrixXi& IndMat,
-                         const Eigen::MatrixXi& EOneIndMat,
-                         const Eigen::MatrixXi& ETwoIndMat){
-
-  Eigen::VectorXd out(EOneIndMat.rows() * p);
-
-  // TODO - Optimize me!
-  for(Eigen::Index i = 0; i < EOneIndMat.rows(); i++){
-    Eigen::VectorXi out_index   = IndMat.row(i);
-    Eigen::VectorXi e_one_index = EOneIndMat.row(i);
-    Eigen::VectorXi e_two_index = ETwoIndMat.row(i);
-
-    for(Eigen::Index j = 0; j < p; j++){
-      out(out_index(j)) = u(e_one_index(j)) - u(e_two_index(j));
-    }
-  }
-
-  return out;
-}
-
-// TODO -- Document me!
-Eigen::VectorXd DtMatOpv2(const Eigen::VectorXd& v,
-                          int n,
-                          int p,
-                          const Eigen::MatrixXi& IndMat,
-                          const Eigen::MatrixXi& EOneIndMat,
-                          const Eigen::MatrixXi& ETwoIndMat){
-
-  Eigen::VectorXd out = Eigen::VectorXd::Zero(n * p);
-  Eigen::VectorXi v_index(p);
-  Eigen::VectorXi e_one_index(p);
-  Eigen::VectorXi e_two_index;
-
-  // TODO - Optimize me!
-  for(Eigen::Index i = 0; i < IndMat.rows(); i++){
-    v_index     = IndMat.row(i);
-    e_one_index = EOneIndMat.row(i);
-    e_two_index = ETwoIndMat.row(i);
-
-    for(Eigen::Index j = 0; j < p; j++){
-      out(e_one_index(j)) += v(v_index(j));
-      out(e_two_index(j)) -= v(v_index(j));
-    }
-  }
-
-  return out;
-}
-
 bool is_nan(double x){
   return x != x;
 }
@@ -86,55 +13,6 @@ int sgn(double x){
   }
   return(ret);
 }
-
-
-// TODO -- Document me!
-Eigen::VectorXd ProxL2(const Eigen::VectorXd& delta,
-                       int p,
-                       const Eigen::VectorXd& scalars,
-                       const Eigen::MatrixXi& IndMat){
-
-  Eigen::Index num_edges = scalars.size();
-  Eigen::VectorXd ret(num_edges * p);
-
-  if(p * num_edges != delta.size()){
-    Rcpp::stop("p * num_edges != delta in ProxL2");
-  }
-
-  if(num_edges != IndMat.rows()){
-    Rcpp::stop("Penalty weights not of same length as number of groups");
-  }
-
-  if(IndMat.size()!= delta.size()){
-    Rcpp::stop("Do not have a group assignment for each data point.");
-  }
-
-
-  // TODO - Optimize this!
-  for(Eigen::Index i = 0; i < num_edges; i++){
-    Eigen::VectorXi index_vec = IndMat.row(i);
-
-    Eigen::VectorXd this_delta = extract(delta, index_vec);
-    double scale_factor = 1 - scalars(i) / this_delta.norm();
-
-    if(is_nan(scale_factor)){
-      for(Eigen::Index j = 0; j < this_delta.size(); j ++){
-        ret(index_vec(j)) = this_delta(j);
-      }
-    } else if(scale_factor < 0){
-      for(Eigen::Index j = 0; j < this_delta.size(); j ++){
-        ret(index_vec(j)) = 0;
-      }
-    } else {
-      for(Eigen::Index j = 0; j < this_delta.size(); j++){
-        ret(index_vec(j)) = scale_factor * this_delta(j);
-      }
-    }
-  }
-
-  return ret;
-}
-
 double soft_thresh(double x, double lambda){
   if(std::abs(x) < lambda){
     return 0;
@@ -143,28 +21,6 @@ double soft_thresh(double x, double lambda){
   } else {
     return x + lambda;
   }
-}
-
-// TODO - Document me!
-Eigen::VectorXd ProxL1(const Eigen::VectorXd& delta,
-                       int p,
-                       double lambda,
-                       const Eigen::VectorXd& weights){
-
-  Eigen::Index num_edges = weights.size();
-  Eigen::VectorXd ret(num_edges * p);
-
-  // TODO - Optimize this!
-  for(Eigen::Index i = 0; i < num_edges; i++){
-    double weight = weights(i);
-
-    for(Eigen::Index j = 0; j < p; j++){
-      Eigen::Index elem_index = i * p + j;
-      ret(elem_index) = soft_thresh(delta(elem_index), weight * lambda);
-    }
-  }
-
-  return ret;
 }
 
 // Modify in place version for internal use

--- a/tests/testthat/helper_clustrviz_tests.R
+++ b/tests/testthat/helper_clustrviz_tests.R
@@ -20,6 +20,18 @@ expect_str_contains <- function(object, expected, info=NULL, label=NULL){
               info=info, label=label)
 }
 
+expect_zero <- function(object, ..., info=NULL, label=NULL, expected.label=NULL){
+  expect_equal(object, 0, ..., info=info, label=label, expected.label=expected.label)
+}
+
+expect_zeros <- function(object, ..., info=NULL, label=NULL, expected.label=NULL){
+  expect_equal(object, rep(0, length(object)), ..., info=info, label=label, expected.label=expected.label)
+}
+
+expect_ones <- function(object, ..., info=NULL, label=NULL, expected.label=NULL){
+  expect_equal(object, rep(1, length(object)), ..., info=info, label=label, expected.label=expected.label)
+}
+
 capture_print <- function(x, ...){
   paste(capture.output(print(x, ...)), collapse="\n")
 }

--- a/tests/testthat/test_carp_error_handling.R
+++ b/tests/testthat/test_carp_error_handling.R
@@ -9,10 +9,6 @@ test_that("CARP() fails with non-finite numerical input", {
 })
 
 test_that("CARP() errors early with incorrect input", {
-  # ADMM Relaxation parameter must be positive
-  expect_error(CARP(presidential_speech, rho = 0))
-  expect_error(CARP(presidential_speech, rho = -1))
-
   # Pre-processing parameters must be boolean flags
   expect_error(CARP(presidential_speech, X.center = NA))
   expect_error(CARP(presidential_speech, X.center = c(TRUE, FALSE)))
@@ -37,22 +33,6 @@ test_that("CARP() errors early with incorrect input", {
   expect_error(CARP(presidential_speech, t = -3))
   expect_error(CARP(presidential_speech, t = NA))
   expect_error(CARP(presidential_speech, t = c(1.3, 1.2)))
-
-  # Check max.iter
-  expect_error(CARP(presidential_speech, max.iter = 1))
-  expect_error(CARP(presidential_speech, max.iter = 75.5))
-  expect_error(CARP(presidential_speech, max.iter = 0))
-  expect_error(CARP(presidential_speech, max.iter = -3))
-  expect_error(CARP(presidential_speech, max.iter = NA))
-  expect_error(CARP(presidential_speech, max.iter = c(5, 10)))
-
-  # Check burn.in
-  expect_error(CARP(presidential_speech, burn.in = 75.5))
-  expect_error(CARP(presidential_speech, burn.in = 0))
-  expect_error(CARP(presidential_speech, burn.in = -3))
-  expect_error(CARP(presidential_speech, burn.in = NA))
-  expect_error(CARP(presidential_speech, burn.in = c(5, 10)))
-  expect_error(CARP(presidential_speech, burn.in = 50, max.iter = 25))
 
   # Fail on unknown flags
   expect_error(CARP(presidential_speech, flag="unknown"), regexp = "flag")

--- a/tests/testthat/test_carp_sparsity_pattern.R
+++ b/tests/testthat/test_carp_sparsity_pattern.R
@@ -1,66 +1,45 @@
-context("test CARP sparsity patterns")
+context("Test CARP Sparsity Invariants")
 
-
-test_that("CARP-returned sparsity pattern begins with no fusions",{
-  carp.fit <- CARP(presidential_speech, alg.type = 'carp')
-  expect_equal(
-    sum(carp.fit$carp.sol.path$v.zero.inds[, 1]),
-    0
-  )
-})
-test_that("CARP-returned sparsity pattern ends with full fusions",{
-  carp.fit <- CARP(presidential_speech, alg.type = 'carp')
-  expect_true(
-    all(carp.fit$carp.sol.path$v.zero.inds[, ncol(carp.fit$carp.sol.path$v.zero.inds)] == 1)
-  )
+test_that("CARP begins with no fusions", {
+  carp_fit <- CARP(presidential_speech, alg.type = 'carp')
+  expect_zeros(carp_fit$carp.sol.path$v.zero.inds[, 1])
 })
 
-test_that("CARPVIZ-returned sparsity pattern begins with no fusions",{
-  carp.fit <- CARP(presidential_speech, alg.type = 'carpviz')
-  expect_equal(
-    sum(carp.fit$carp.sol.path$v.zero.inds[, 1]),
-    0
-  )
-})
-test_that("CARPVIZ-returned sparsity pattern ends with full fusions",{
-  carp.fit <- CARP(presidential_speech,alg.type='carpviz')
-  expect_true(
-    all(carp.fit$carp.sol.path$v.zero.inds[, ncol(carp.fit$carp.sol.path$v.zero.inds)] == 1)
-  )
+test_that("CARP ends with all fusions", {
+  carp_fit <- CARP(presidential_speech, alg.type = 'carp')
+  expect_ones(carp_fit$carp.sol.path$v.zero.inds[, NCOL(carp_fit$carp.sol.path$v.zero.inds)])
 })
 
-
-
-
-
-test_that("CARP-returned sparsity pattern begins with no fusions (uniform weights)",{
-  weight_mat <-matrix(1, nrow=nrow(presidential_speech), ncol=nrow(presidential_speech))
-  carp.fit <- CARP(presidential_speech, weights = weight_mat, alg.type = 'carp')
-  expect_equal(
-    sum(carp.fit$carp.sol.path$v.zero.inds[, 1]),
-    0
-  )
-})
-test_that("CARP-returned sparsity pattern ends with full fusions (uniform weights)",{
-  weight_mat <-matrix(1, nrow=nrow(presidential_speech), ncol=nrow(presidential_speech))
-  carp.fit <- CARP(presidential_speech, weights = weight_mat, alg.type='carp')
-  expect_true(
-    all(carp.fit$carp.sol.path$v.zero.inds[, ncol(carp.fit$carp.sol.path$v.zero.inds)] == 1)
-  )
+test_that("CARP-VIZ begins with no fusions", {
+  carp_fit <- CARP(presidential_speech, alg.type = 'carpviz')
+  expect_zeros(carp_fit$carp.sol.path$v.zero.inds[, 1])
 })
 
-test_that("CARPVIZ-returned sparsity pattern begins with no fusions (uniform weights)",{
-  weight_mat <-matrix(1, nrow=nrow(presidential_speech), ncol=nrow(presidential_speech))
-  carp.fit <- CARP(presidential_speech, alg.type = 'carpviz', weights = weight_mat)
-  expect_equal(
-    sum(carp.fit$carp.sol.path$v.zero.inds[, 1]),
-    0
-  )
+test_that("CARP-VIZ ends with all fusions", {
+  carp_fit <- CARP(presidential_speech,alg.type='carpviz')
+  expect_ones(carp_fit$carp.sol.path$v.zero.inds[, NCOL(carp_fit$carp.sol.path$v.zero.inds)])
 })
-test_that("CARPVIZ-returned sparsity pattern ends with full fusions (uniform weights)",{
-  weight_mat <-matrix(1, nrow=nrow(presidential_speech), ncol=nrow(presidential_speech))
-  carp.fit <- CARP(presidential_speech, alg.type='carpviz', weights = weight_mat)
-  expect_true(
-    all(carp.fit$carp.sol.path$v.zero.inds[, ncol(carp.fit$carp.sol.path$v.zero.inds)] == 1)
-  )
+
+test_that("CARP begins with no fusions (uniform weights)", {
+  weight_mat <- matrix(1, nrow=NROW(presidential_speech), ncol=NROW(presidential_speech))
+  carp_fit   <- CARP(presidential_speech, weights = weight_mat, alg.type = 'carp')
+  expect_zeros(carp_fit$carp.sol.path$v.zero.inds[, 1])
+})
+
+test_that("CARP ends with all fusions (uniform weights)", {
+  weight_mat <- matrix(1, nrow=NROW(presidential_speech), ncol=NROW(presidential_speech))
+  carp_fit   <- CARP(presidential_speech, weights = weight_mat, alg.type = 'carp')
+  expect_ones(carp_fit$carp.sol.path$v.zero.inds[, NCOL(carp_fit$carp.sol.path$v.zero.inds)])
+})
+
+test_that("CARP-VIZ begins with no fusions (uniform weights)", {
+  weight_mat <- matrix(1, nrow=NROW(presidential_speech), ncol=NROW(presidential_speech))
+  carp_fit   <- CARP(presidential_speech, weights = weight_mat, alg.type = 'carpviz')
+  expect_zeros(carp_fit$carp.sol.path$v.zero.inds[, 1])
+})
+
+test_that("CARP-VIZ ends with all fusions (uniform weights)", {
+  weight_mat <- matrix(1, nrow=NROW(presidential_speech), ncol=NROW(presidential_speech))
+  carp_fit   <- CARP(presidential_speech, weights = weight_mat, alg.type = 'carpviz')
+  expect_ones(carp_fit$carp.sol.path$v.zero.inds[, NCOL(carp_fit$carp.sol.path$v.zero.inds)])
 })

--- a/tests/testthat/test_cbass_accessors.R
+++ b/tests/testthat/test_cbass_accessors.R
@@ -5,35 +5,35 @@ test_that("Input checking works", {
 
   ## Exactly one argument required
   expect_error(clustering(cbass_fit))
-  expect_error(clustering(cbass_fit, k.obs = 5, k.var = 5))
-  expect_error(clustering(cbass_fit, k.obs = 5, percent = 0.5))
-  expect_error(clustering(cbass_fit, k.var = 5, percent = 0.5))
-  expect_error(clustering(cbass_fit, k.obs = 5, k.var = 5, percent = 0.5))
+  expect_error(clustering(cbass_fit, k.row = 5, k.col = 5))
+  expect_error(clustering(cbass_fit, k.row = 5, percent = 0.5))
+  expect_error(clustering(cbass_fit, k.col = 5, percent = 0.5))
+  expect_error(clustering(cbass_fit, k.row = 5, k.col = 5, percent = 0.5))
 
   ## Get cluster labels
 
   ## Exactly one argument required
   expect_error(get_cluster_labels(cbass_fit))
-  expect_error(get_cluster_labels(cbass_fit, k.obs = 5, k.var = 5))
-  expect_error(get_cluster_labels(cbass_fit, k.obs = 5, percent = 0.5))
-  expect_error(get_cluster_labels(cbass_fit, k.var = 5, percent = 0.5))
-  expect_error(get_cluster_labels(cbass_fit, k.obs = 5, k.var = 5, percent = 0.5))
+  expect_error(get_cluster_labels(cbass_fit, k.row = 5, k.col = 5))
+  expect_error(get_cluster_labels(cbass_fit, k.row = 5, percent = 0.5))
+  expect_error(get_cluster_labels(cbass_fit, k.col = 5, percent = 0.5))
+  expect_error(get_cluster_labels(cbass_fit, k.row = 5, k.col = 5, percent = 0.5))
 
-  ## Bad k.obs
-  expect_error(get_cluster_labels(cbass_fit, k.obs = 2.5))
-  expect_error(get_cluster_labels(cbass_fit, k.obs = 0))
-  expect_error(get_cluster_labels(cbass_fit, k.obs = -3))
-  expect_error(get_cluster_labels(cbass_fit, k.obs = NROW(presidential_speech) + 4))
-  expect_error(get_cluster_labels(cbass_fit, k.obs = NA))
-  expect_error(get_cluster_labels(cbass_fit, k.obs = c(2, 5)))
+  ## Bad k.row
+  expect_error(get_cluster_labels(cbass_fit, k.row = 2.5))
+  expect_error(get_cluster_labels(cbass_fit, k.row = 0))
+  expect_error(get_cluster_labels(cbass_fit, k.row = -3))
+  expect_error(get_cluster_labels(cbass_fit, k.row = NROW(presidential_speech) + 4))
+  expect_error(get_cluster_labels(cbass_fit, k.row = NA))
+  expect_error(get_cluster_labels(cbass_fit, k.row = c(2, 5)))
 
-  ## Bad k.var
-  expect_error(get_cluster_labels(cbass_fit, k.var = 2.5))
-  expect_error(get_cluster_labels(cbass_fit, k.var = 0))
-  expect_error(get_cluster_labels(cbass_fit, k.var = -3))
-  expect_error(get_cluster_labels(cbass_fit, k.var = NCOL(presidential_speech) + 4))
-  expect_error(get_cluster_labels(cbass_fit, k.var = NA))
-  expect_error(get_cluster_labels(cbass_fit, k.var = c(2, 5)))
+  ## Bad k.col
+  expect_error(get_cluster_labels(cbass_fit, k.col = 2.5))
+  expect_error(get_cluster_labels(cbass_fit, k.col = 0))
+  expect_error(get_cluster_labels(cbass_fit, k.col = -3))
+  expect_error(get_cluster_labels(cbass_fit, k.col = NCOL(presidential_speech) + 4))
+  expect_error(get_cluster_labels(cbass_fit, k.col = NA))
+  expect_error(get_cluster_labels(cbass_fit, k.col = c(2, 5)))
 
   ## Bad percent
   expect_error(get_cluster_labels(cbass_fit, percent = 1.5))
@@ -51,26 +51,26 @@ test_that("Input checking works", {
 
   ## Exactly one argument required
   expect_error(get_clustered_data(cbass_fit))
-  expect_error(get_clustered_data(cbass_fit, k.obs = 5, k.var = 5))
-  expect_error(get_clustered_data(cbass_fit, k.obs = 5, percent = 0.5))
-  expect_error(get_clustered_data(cbass_fit, k.var = 5, percent = 0.5))
-  expect_error(get_clustered_data(cbass_fit, k.obs = 5, k.var = 5, percent = 0.5))
+  expect_error(get_clustered_data(cbass_fit, k.row = 5, k.col = 5))
+  expect_error(get_clustered_data(cbass_fit, k.row = 5, percent = 0.5))
+  expect_error(get_clustered_data(cbass_fit, k.col = 5, percent = 0.5))
+  expect_error(get_clustered_data(cbass_fit, k.row = 5, k.col = 5, percent = 0.5))
 
-  ## Bad k.obs
-  expect_error(get_clustered_data(cbass_fit, k.obs = 2.5))
-  expect_error(get_clustered_data(cbass_fit, k.obs = 0))
-  expect_error(get_clustered_data(cbass_fit, k.obs = -3))
-  expect_error(get_clustered_data(cbass_fit, k.obs = NROW(presidential_speech) + 4))
-  expect_error(get_clustered_data(cbass_fit, k.obs = NA))
-  expect_error(get_clustered_data(cbass_fit, k.obs = c(2, 5)))
+  ## Bad k.row
+  expect_error(get_clustered_data(cbass_fit, k.row = 2.5))
+  expect_error(get_clustered_data(cbass_fit, k.row = 0))
+  expect_error(get_clustered_data(cbass_fit, k.row = -3))
+  expect_error(get_clustered_data(cbass_fit, k.row = NROW(presidential_speech) + 4))
+  expect_error(get_clustered_data(cbass_fit, k.row = NA))
+  expect_error(get_clustered_data(cbass_fit, k.row = c(2, 5)))
 
-  ## Bad k.var
-  expect_error(get_clustered_data(cbass_fit, k.var = 2.5))
-  expect_error(get_clustered_data(cbass_fit, k.var = 0))
-  expect_error(get_clustered_data(cbass_fit, k.var = -3))
-  expect_error(get_clustered_data(cbass_fit, k.var = NCOL(presidential_speech) + 4))
-  expect_error(get_clustered_data(cbass_fit, k.var = NA))
-  expect_error(get_clustered_data(cbass_fit, k.var = c(2, 5)))
+  ## Bad k.col
+  expect_error(get_clustered_data(cbass_fit, k.col = 2.5))
+  expect_error(get_clustered_data(cbass_fit, k.col = 0))
+  expect_error(get_clustered_data(cbass_fit, k.col = -3))
+  expect_error(get_clustered_data(cbass_fit, k.col = NCOL(presidential_speech) + 4))
+  expect_error(get_clustered_data(cbass_fit, k.col = NA))
+  expect_error(get_clustered_data(cbass_fit, k.col = c(2, 5)))
 
   ## Bad percent
   expect_error(get_clustered_data(cbass_fit, percent = 1.5))
@@ -85,83 +85,83 @@ test_that("Input checking works", {
   expect_error(get_clustered_data(cbass_fit, arg = 5))
 })
 
-test_that("get_cluster_labels.CBASS works on observation labels", {
+test_that("get_cluster_labels.CBASS works on row labels", {
   cbass_fit <- CBASS(presidential_speech)
 
-  labels <- get_cluster_labels(cbass_fit, k.obs = 1, type = "obs")
+  labels <- get_cluster_labels(cbass_fit, k.row = 1, type = "row")
   names(labels) <- NULL
 
   expect_equal(labels,
                factor(rep("cluster_1", NROW(presidential_speech))))
 
   ## Known k
-  expect_equal(levels(get_cluster_labels(cbass_fit, k.obs = 3, type = "obs")),
+  expect_equal(levels(get_cluster_labels(cbass_fit, k.row = 3, type = "row")),
                c("cluster_1", "cluster_2", "cluster_3"))
 
   for (k in 1:10) {
-    expect_equal(k, nlevels(get_cluster_labels(cbass_fit, k.obs = k, type = "obs")))
+    expect_equal(k, nlevels(get_cluster_labels(cbass_fit, k.row = k, type = "row")))
   }
 
   ## Should have correct names
-  labels <- get_cluster_labels(cbass_fit, k.obs = 3, type = "obs")
+  labels <- get_cluster_labels(cbass_fit, k.row = 3, type = "row")
   expect_equal(rownames(presidential_speech), names(labels))
 
   ## Distinct clusters at beginning of path
   expect_equal(NROW(presidential_speech),
                num_unique(get_cluster_labels(cbass_fit,
-                                             k.obs = NROW(presidential_speech),
-                                             type = "obs")))
+                                             k.row = NROW(presidential_speech),
+                                             type = "row")))
 
   expect_equal(NROW(presidential_speech),
-               num_unique(get_cluster_labels(cbass_fit, percent = 0, type = "obs")))
+               num_unique(get_cluster_labels(cbass_fit, percent = 0, type = "row")))
 
   ## Mono-cluster at end of path
-  expect_equal(1, num_unique(get_cluster_labels(cbass_fit, k.obs = 1, type = "obs")))
-  expect_equal(1, num_unique(get_cluster_labels(cbass_fit, percent = 1, type = "obs")))
+  expect_equal(1, num_unique(get_cluster_labels(cbass_fit, k.row = 1, type = "row")))
+  expect_equal(1, num_unique(get_cluster_labels(cbass_fit, percent = 1, type = "row")))
 
   ## Correct number of labels returned
   for(pct in seq(0, 1, length.out = 21)){
-    expect_equal(length(get_cluster_labels(cbass_fit, percent = pct, type = "obs")), NROW(presidential_speech))
+    expect_equal(length(get_cluster_labels(cbass_fit, percent = pct, type = "row")), NROW(presidential_speech))
   }
 })
 
-test_that("get_cluster_labels.CBASS works on variable labels", {
+test_that("get_cluster_labels.CBASS works on column labels", {
   cbass_fit <- CBASS(presidential_speech)
 
-  labels <- get_cluster_labels(cbass_fit, k.var = 1, type = "var")
+  labels <- get_cluster_labels(cbass_fit, k.col = 1, type = "col")
   names(labels) <- NULL
 
   expect_equal(labels,
                factor(rep("cluster_1", NCOL(presidential_speech))))
 
   ## Known k
-  expect_equal(levels(get_cluster_labels(cbass_fit, k.var = 3, type = "var")),
+  expect_equal(levels(get_cluster_labels(cbass_fit, k.col = 3, type = "col")),
                c("cluster_1", "cluster_2", "cluster_3"))
 
   for (k in 1:10) {
-    expect_equal(k, nlevels(get_cluster_labels(cbass_fit, k.var = k, type = "var")))
+    expect_equal(k, nlevels(get_cluster_labels(cbass_fit, k.col = k, type = "col")))
   }
 
   ## Should have correct names
-  labels <- get_cluster_labels(cbass_fit, k.var = 3, type = "var")
+  labels <- get_cluster_labels(cbass_fit, k.col = 3, type = "col")
   expect_equal(colnames(presidential_speech), names(labels))
 
   ## Distinct clusters at beginning of path
   expect_equal(NCOL(presidential_speech),
                num_unique(get_cluster_labels(cbass_fit,
-                                             k.var = NCOL(presidential_speech),
-                                             type = "var")))
+                                             k.col = NCOL(presidential_speech),
+                                             type = "col")))
 
   expect_equal(NCOL(presidential_speech),
-               num_unique(get_cluster_labels(cbass_fit, percent = 0, type = "var")))
+               num_unique(get_cluster_labels(cbass_fit, percent = 0, type = "col")))
 
   ## Mono-cluster at end of path
-  expect_equal(1, num_unique(get_cluster_labels(cbass_fit, k.var = 1, type = "var")))
-  expect_equal(1, num_unique(get_cluster_labels(cbass_fit, percent = 1, type = "var")))
+  expect_equal(1, num_unique(get_cluster_labels(cbass_fit, k.col = 1, type = "col")))
+  expect_equal(1, num_unique(get_cluster_labels(cbass_fit, percent = 1, type = "col")))
 
   ## Correct number of labels returned
   for(pct in seq(0, 1, length.out = 21)){
-    expect_equal(length(get_cluster_labels(cbass_fit, percent = pct, type = "var")), NCOL(presidential_speech))
+    expect_equal(length(get_cluster_labels(cbass_fit, percent = pct, type = "col")), NCOL(presidential_speech))
   }
 })
 
@@ -173,21 +173,21 @@ test_that("get_cluster_centroids.CBASS works", {
 
   for(cbass_fit in cbass_fits){
     ## Cluster centroids matrix has k1-times-k2 distinct elements
-    ## for k1 obs clusters and k2 var clusters
+    ## for k1 row clusters and k2 col clusters
     ##
     ## These elements are typically unique, but weird things can happen
     ## (particularly near the end of the path) so we don't test
     for(k in 1:10){
-      obs_labels <- num_unique(get_cluster_labels(cbass_fit, k.obs = k, type = "obs"))
-      var_labels <- num_unique(get_cluster_labels(cbass_fit, k.obs = k, type = "var"))
-      expect_equal(length(get_cluster_centroids(cbass_fit, k.obs = k)), obs_labels * var_labels)
+      row_labels <- num_unique(get_cluster_labels(cbass_fit, k.row = k, type = "row"))
+      col_labels <- num_unique(get_cluster_labels(cbass_fit, k.row = k, type = "col"))
+      expect_equal(length(get_cluster_centroids(cbass_fit, k.row = k)), row_labels * col_labels)
 
-      obs_labels <- num_unique(get_cluster_labels(cbass_fit, k.var = k, type = "obs"))
-      var_labels <- num_unique(get_cluster_labels(cbass_fit, k.var = k, type = "var"))
-      expect_equal(length(get_cluster_centroids(cbass_fit, k.var = k)), obs_labels * var_labels)
+      row_labels <- num_unique(get_cluster_labels(cbass_fit, k.col = k, type = "row"))
+      col_labels <- num_unique(get_cluster_labels(cbass_fit, k.col = k, type = "col"))
+      expect_equal(length(get_cluster_centroids(cbass_fit, k.col = k)), row_labels * col_labels)
 
-      expect_is(get_cluster_centroids(cbass_fit, k.obs = k), "matrix")
-      expect_is(get_cluster_centroids(cbass_fit, k.var = k), "matrix")
+      expect_is(get_cluster_centroids(cbass_fit, k.row = k), "matrix")
+      expect_is(get_cluster_centroids(cbass_fit, k.col = k), "matrix")
     }
 
     ## At full fusion, we should get a single element that is the grand mean
@@ -212,81 +212,81 @@ test_that("get_clustered_data.CBASS works", {
 
   for(cbass_fit in cbass_fits){
     ## Clustered data matrix has at most k1-times-k2 distinct elements
-    ## for k1 obs clusters and k2 var clusters
+    ## for k1 row clusters and k2 col clusters
     ##
-    ## It can have fewer if a pair of clusters on the "same side" (obs or var) are
+    ## It can have fewer if a pair of clusters on the "same side" (row or col) are
     ## nested in a single cluster on the other side
     for(k in 1:10){
-      obs_labels <- num_unique(get_cluster_labels(cbass_fit, k.obs = k, type = "obs"))
-      var_labels <- num_unique(get_cluster_labels(cbass_fit, k.obs = k, type = "var"))
-      expect_lte(num_unique(get_clustered_data(cbass_fit, k.obs = k)), obs_labels * var_labels)
+      row_labels <- num_unique(get_cluster_labels(cbass_fit, k.row = k, type = "row"))
+      col_labels <- num_unique(get_cluster_labels(cbass_fit, k.row = k, type = "col"))
+      expect_lte(num_unique(get_clustered_data(cbass_fit, k.row = k)), row_labels * col_labels)
 
-      obs_labels <- num_unique(get_cluster_labels(cbass_fit, k.var = k, type = "obs"))
-      var_labels <- num_unique(get_cluster_labels(cbass_fit, k.var = k, type = "var"))
-      expect_lte(num_unique(get_clustered_data(cbass_fit, k.var = k)), obs_labels * var_labels)
+      row_labels <- num_unique(get_cluster_labels(cbass_fit, k.col = k, type = "row"))
+      col_labels <- num_unique(get_cluster_labels(cbass_fit, k.col = k, type = "col"))
+      expect_lte(num_unique(get_clustered_data(cbass_fit, k.col = k)), row_labels * col_labels)
 
       # Correct size
-      expect_equal(dim(presidential_speech), dim(get_clustered_data(cbass_fit, k.obs = k)))
-      expect_equal(dim(presidential_speech), dim(get_clustered_data(cbass_fit, k.var = k)))
+      expect_equal(dim(presidential_speech), dim(get_clustered_data(cbass_fit, k.row = k)))
+      expect_equal(dim(presidential_speech), dim(get_clustered_data(cbass_fit, k.col = k)))
 
       # Correct names
-      expect_equal(dimnames(presidential_speech), dimnames(get_clustered_data(cbass_fit, k.obs = k)))
-      expect_equal(dimnames(presidential_speech), dimnames(get_clustered_data(cbass_fit, k.var = k)))
+      expect_equal(dimnames(presidential_speech), dimnames(get_clustered_data(cbass_fit, k.row = k)))
+      expect_equal(dimnames(presidential_speech), dimnames(get_clustered_data(cbass_fit, k.col = k)))
     }
 
     # Expect mono-cluster at end of path
     presidential_speech_full_cluster <- presidential_speech * 0 + mean(presidential_speech)
 
     ## The variables are fully clustered before the observations, so this doesn't actully work
-    # expect_equal(presidential_speech_full_cluster, get_clustered_data(cbass_fit, k.var = 1))
-    expect_equal(presidential_speech_full_cluster, get_clustered_data(cbass_fit, k.obs = 1))
+    # expect_equal(presidential_speech_full_cluster, get_clustered_data(cbass_fit, k.col = 1))
+    expect_equal(presidential_speech_full_cluster, get_clustered_data(cbass_fit, k.row = 1))
     expect_equal(presidential_speech_full_cluster, get_clustered_data(cbass_fit, percent = 1))
 
     ## Clustered data are the centers from raw data, regardless of pre-processing flags
-    ## Fix k.obs
-    obs_labels <- as.integer(get_cluster_labels(cbass_fit, k.obs = 2, type = "obs"))
-    var_labels <- as.integer(get_cluster_labels(cbass_fit, k.obs = 2, type = "var"))
-    clustered_data_matrix <- get_clustered_data(cbass_fit, k.obs = 2)
+    ## Fix k.row
+    row_labels <- as.integer(get_cluster_labels(cbass_fit, k.row = 2, type = "row"))
+    col_labels <- as.integer(get_cluster_labels(cbass_fit, k.row = 2, type = "col"))
+    clustered_data_matrix <- get_clustered_data(cbass_fit, k.row = 2)
     expect_equal(colnames(clustered_data_matrix), colnames(presidential_speech))
     expect_equal(rownames(clustered_data_matrix), rownames(presidential_speech))
 
-    for(o in unique(obs_labels)){
-      for(v in unique(var_labels)){
-        expect_equal(num_unique(clustered_data_matrix[obs_labels == o, var_labels == v]), 1)
-        expect_equal(mean(clustered_data_matrix[obs_labels == o, var_labels == v]),
-                     mean(presidential_speech[obs_labels == o, var_labels == v]))
+    for(r in unique(row_labels)){
+      for(c in unique(col_labels)){
+        expect_equal(num_unique(clustered_data_matrix[row_labels == r, col_labels == c]), 1)
+        expect_equal(mean(clustered_data_matrix[row_labels == r, col_labels == c]),
+                     mean(presidential_speech[row_labels == r, col_labels == c]))
       }
     }
 
-    ## Fix k.var
-    obs_labels <- as.integer(get_cluster_labels(cbass_fit, k.var = 2, type = "obs"))
-    var_labels <- as.integer(get_cluster_labels(cbass_fit, k.var = 2, type = "var"))
-    clustered_data_matrix <- get_clustered_data(cbass_fit, k.var = 2)
+    ## Fix k.col
+    row_labels <- as.integer(get_cluster_labels(cbass_fit, k.col = 2, type = "row"))
+    col_labels <- as.integer(get_cluster_labels(cbass_fit, k.col = 2, type = "col"))
+    clustered_data_matrix <- get_clustered_data(cbass_fit, k.col = 2)
     expect_equal(colnames(clustered_data_matrix), colnames(presidential_speech))
     expect_equal(rownames(clustered_data_matrix), rownames(presidential_speech))
 
     ## Clustered data are the centers from raw data, regardless of pre-processing flags
-    for(o in unique(obs_labels)){
-      for(v in unique(var_labels)){
-        expect_equal(num_unique(clustered_data_matrix[obs_labels == o, var_labels == v]), 1)
-        expect_equal(mean(clustered_data_matrix[obs_labels == o, var_labels == v]),
-                     mean(presidential_speech[obs_labels == o, var_labels == v]))
+    for(r in unique(row_labels)){
+      for(c in unique(col_labels)){
+        expect_equal(num_unique(clustered_data_matrix[row_labels == r, col_labels == c]), 1)
+        expect_equal(mean(clustered_data_matrix[row_labels == r, col_labels == c]),
+                     mean(presidential_speech[row_labels == r, col_labels == c]))
       }
     }
 
     ## Fix percent
-    obs_labels <- as.integer(get_cluster_labels(cbass_fit, percent = 0.9, type = "obs"))
-    var_labels <- as.integer(get_cluster_labels(cbass_fit, percent = 0.9, type = "var"))
+    row_labels <- as.integer(get_cluster_labels(cbass_fit, percent = 0.9, type = "row"))
+    col_labels <- as.integer(get_cluster_labels(cbass_fit, percent = 0.9, type = "col"))
     clustered_data_matrix <- get_clustered_data(cbass_fit, percent = 0.9)
     expect_equal(colnames(clustered_data_matrix), colnames(presidential_speech))
     expect_equal(rownames(clustered_data_matrix), rownames(presidential_speech))
 
     ## Clustered data are the centers from raw data, regardless of pre-processing flags
-    for(o in unique(obs_labels)){
-      for(v in unique(var_labels)){
-        expect_equal(num_unique(clustered_data_matrix[obs_labels == o, var_labels == v]), 1)
-        expect_equal(mean(clustered_data_matrix[obs_labels == o, var_labels == v]),
-                     mean(presidential_speech[obs_labels == o, var_labels == v]))
+    for(r in unique(row_labels)){
+      for(c in unique(col_labels)){
+        expect_equal(num_unique(clustered_data_matrix[row_labels == r, col_labels == c]), 1)
+        expect_equal(mean(clustered_data_matrix[row_labels == r, col_labels == c]),
+                     mean(presidential_speech[row_labels == r, col_labels == c]))
       }
     }
   }

--- a/tests/testthat/test_cbass_error_handling.R
+++ b/tests/testthat/test_cbass_error_handling.R
@@ -9,10 +9,6 @@ test_that("CBASS() fails with non-finite numerical input", {
 })
 
 test_that("CBASS() errors early with incorrect input", {
-  # ADMM Relaxation parameter must be positive
-  expect_error(CBASS(presidential_speech, rho = 0))
-  expect_error(CBASS(presidential_speech, rho = -1))
-
   # Pre-processing parameters must be boolean flags
   expect_error(CBASS(presidential_speech, X.center.global = NA))
   expect_error(CBASS(presidential_speech, X.center.global = c(TRUE, FALSE)))
@@ -34,22 +30,6 @@ test_that("CBASS() errors early with incorrect input", {
   expect_error(CBASS(presidential_speech, t = -3))
   expect_error(CBASS(presidential_speech, t = NA))
   expect_error(CBASS(presidential_speech, t = c(1.3, 1.2)))
-
-  # Check max.iter
-  expect_error(CBASS(presidential_speech, max.iter = 1))
-  expect_error(CBASS(presidential_speech, max.iter = 75.5))
-  expect_error(CBASS(presidential_speech, max.iter = 0))
-  expect_error(CBASS(presidential_speech, max.iter = -3))
-  expect_error(CBASS(presidential_speech, max.iter = NA))
-  expect_error(CBASS(presidential_speech, max.iter = c(5, 10)))
-
-  # Check burn.in
-  expect_error(CBASS(presidential_speech, burn.in = 75.5))
-  expect_error(CBASS(presidential_speech, burn.in = 0))
-  expect_error(CBASS(presidential_speech, burn.in = -3))
-  expect_error(CBASS(presidential_speech, burn.in = NA))
-  expect_error(CBASS(presidential_speech, burn.in = c(5, 10)))
-  expect_error(CBASS(presidential_speech, burn.in = 50, max.iter = 25))
 
   # Fail on unknown flags
   expect_error(CBASS(presidential_speech, flag="unknown"), regexp = "flag")

--- a/tests/testthat/test_cbass_misc.R
+++ b/tests/testthat/test_cbass_misc.R
@@ -16,8 +16,8 @@ test_that("CBASS creates unique names if needed", {
 test_that("CBASS supports factor labels", {
   X <- matrix(rnorm(9), 3, 3)
 
-  cbass_fit <- CBASS(X, obs_labels = factor(c("a", "b", "c")),
-                        var_labels = factor(c("d", "e", "f")))
+  cbass_fit <- CBASS(X, row_labels = factor(c("a", "b", "c")),
+                        col_labels = factor(c("d", "e", "f")))
 
   expect_equal(rownames(cbass_fit$X), c("a", "b", "c"))
   expect_equal(colnames(cbass_fit$X), c("d", "e", "f"))

--- a/tests/testthat/test_cbass_plot_save.R
+++ b/tests/testthat/test_cbass_plot_save.R
@@ -9,18 +9,18 @@ test_that("saveviz.CBASS can save a dynamic heatmap", {
   expect_no_error(saveviz(cbass_fit, file.name = tempfile(), plot.type = "heatmap", dynamic = TRUE))
 })
 
-test_that("saveviz.CBASS can save a dynamic observation dendrogram", {
+test_that("saveviz.CBASS can save a dynamic row dendrogram", {
   skip("Need to rework dynamic visualizations")
 
   cbass_fit <- CBASS(presidential_speech)
-  expect_no_error(saveviz(cbass_fit, file.name = tempfile(), plot.type = "obs.dendrogram", dynamic = TRUE))
+  expect_no_error(saveviz(cbass_fit, file.name = tempfile(), plot.type = "row.dendrogram", dynamic = TRUE))
 })
 
-test_that("saveviz.CBASS can save a dynamic variable dendrogram", {
+test_that("saveviz.CBASS can save a dynamic column dendrogram", {
   skip("Need to rework dynamic visualizations")
 
   cbass_fit <- CBASS(presidential_speech)
-  expect_no_error(saveviz(cbass_fit, file.name = tempfile(), plot.type = "var.dendrogram", dynamic = TRUE))
+  expect_no_error(saveviz(cbass_fit, file.name = tempfile(), plot.type = "col.dendrogram", dynamic = TRUE))
 })
 test_that("saveviz.CBASS can save a static heatmap as a PNG", {
   skip_on_cran()
@@ -31,41 +31,41 @@ test_that("saveviz.CBASS can save a static heatmap as a PNG", {
   expect_true(file.exists(temp_file))
 })
 
-test_that("saveviz.CBASS can save a static observation dendrogram as a JPG", {
+test_that("saveviz.CBASS can save a static row dendrogram as a JPG", {
   skip_on_cran()
 
   cbass_fit <- CBASS(presidential_speech)
   temp_file <- file.path(tempdir(), "tester.jpg")
-  expect_equal(invisible(temp_file), saveviz(cbass_fit, file.name = temp_file, type = "obs.dendrogram", dynamic = FALSE))
+  expect_equal(invisible(temp_file), saveviz(cbass_fit, file.name = temp_file, type = "row.dendrogram", dynamic = FALSE))
   expect_true(file.exists(temp_file))
 })
 
 
-test_that("saveviz.CBASS can save a static variable dendrogram as a PDF", {
+test_that("saveviz.CBASS can save a static column dendrogram as a PDF", {
   skip_on_cran()
 
   cbass_fit <- CBASS(presidential_speech)
   temp_file <- file.path(tempdir(), "tester.pdf")
-  expect_equal(invisible(temp_file), saveviz(cbass_fit, file.name = temp_file, type = "var.dendrogram", dynamic = FALSE))
+  expect_equal(invisible(temp_file), saveviz(cbass_fit, file.name = temp_file, type = "col.dendrogram", dynamic = FALSE))
   expect_true(file.exists(temp_file))
 })
 
-test_that("saveviz.CBASS can save a dynamic observation dendrogram as a GIF", {
+test_that("saveviz.CBASS can save a dynamic row dendrogram as a GIF", {
   skip_on_cran()
 
   cbass_fit <- CBASS(presidential_speech)
   temp_file <- file.path(tempdir(), "tester.gif")
-  expect_no_warning(sv_res <- saveviz(cbass_fit, file.name = temp_file, type = "obs.dendrogram", dynamic = TRUE))
+  expect_no_warning(sv_res <- saveviz(cbass_fit, file.name = temp_file, type = "row.dendrogram", dynamic = TRUE))
   expect_equal(sv_res, invisible(temp_file))
   expect_true(file.exists(temp_file))
 })
 
-test_that("saveviz.CBASS can save a dynamic variable dendrogram as a GIF", {
+test_that("saveviz.CBASS can save a dynamic column dendrogram as a GIF", {
   skip_on_cran()
 
   cbass_fit <- CBASS(presidential_speech)
   temp_file <- file.path(tempdir(), "tester.gif")
-  expect_no_warning(sv_res <- saveviz(cbass_fit, file.name = temp_file, type = "var.dendrogram", dynamic = TRUE))
+  expect_no_warning(sv_res <- saveviz(cbass_fit, file.name = temp_file, type = "col.dendrogram", dynamic = TRUE))
   expect_equal(sv_res, invisible(temp_file))
   expect_true(file.exists(temp_file))
 })

--- a/tests/testthat/test_cbass_plot_static.R
+++ b/tests/testthat/test_cbass_plot_static.R
@@ -5,150 +5,150 @@ context("Test Static CBASS Plots")
 ## Right now these are just "smoke" tests (i.e., runs in the default way without error)
 ## but we will add actual tests later (see GH #44)
 
-test_that("CBASS path plot works for observations", {
+test_that("CBASS path plot works for rows", {
   cbass_fit <- CBASS(presidential_speech)
 
   ## Main settings work
-  expect_no_error(plot(cbass_fit, type = "obs.path"))
-  expect_is(plot(cbass_fit, type = "obs.path"), "gg")
+  expect_no_error(plot(cbass_fit, type = "row.path"))
+  expect_is(plot(cbass_fit, type = "row.path"), "gg")
 
   ## Can only plot pre-calculated PCs right now
   ## FIXME -- See GH #24
-  expect_error(plot(cbass_fit, type = "obs.path", k.obs  = 3, axis = c("amount", "appropri")))
-  expect_error(plot(cbass_fit, type = "obs.path", k.obs  = 3, axis = c("PC1", "PC5")))
+  expect_error(plot(cbass_fit, type = "row.path", k.row  = 3, axis = c("amount", "appropri")))
+  expect_error(plot(cbass_fit, type = "row.path", k.row  = 3, axis = c("PC1", "PC5")))
 
-  ## Must give at most one of `percent`, `k.obs`, `k.var`
-  expect_error(plot(cbass_fit, type = "obs.path", percent = 0.5, k.obs = 3))
-  expect_error(plot(cbass_fit, type = "obs.path", percent = 0.5, k.var = 3))
-  expect_error(plot(cbass_fit, type = "obs.path", k.obs = 3, k.var = 3))
+  ## Must give at most one of `percent`, `k.row`, `k.col`
+  expect_error(plot(cbass_fit, type = "row.path", percent = 0.5, k.row = 3))
+  expect_error(plot(cbass_fit, type = "row.path", percent = 0.5, k.col = 3))
+  expect_error(plot(cbass_fit, type = "row.path", k.row = 3, k.col = 3))
 
   ## Error checking on `percent` and `k`
-  expect_error(plot(cbass_fit, type = "obs.path", percent = 1.5))
-  expect_error(plot(cbass_fit, type = "obs.path", percent = -0.5))
-  expect_error(plot(cbass_fit, type = "obs.path", percent = NA))
-  expect_error(plot(cbass_fit, type = "obs.path", percent = c(0.25, 0.75)))
+  expect_error(plot(cbass_fit, type = "row.path", percent = 1.5))
+  expect_error(plot(cbass_fit, type = "row.path", percent = -0.5))
+  expect_error(plot(cbass_fit, type = "row.path", percent = NA))
+  expect_error(plot(cbass_fit, type = "row.path", percent = c(0.25, 0.75)))
 
-  expect_error(plot(cbass_fit, type = "obs.path", k.obs = 3.5))
-  expect_error(plot(cbass_fit, type = "obs.path", k.obs = 0))
-  expect_error(plot(cbass_fit, type = "obs.path", k.obs = -1))
-  expect_error(plot(cbass_fit, type = "obs.path", k.obs = NROW(presidential_speech) + 1))
+  expect_error(plot(cbass_fit, type = "row.path", k.row = 3.5))
+  expect_error(plot(cbass_fit, type = "row.path", k.row = 0))
+  expect_error(plot(cbass_fit, type = "row.path", k.row = -1))
+  expect_error(plot(cbass_fit, type = "row.path", k.row = NROW(presidential_speech) + 1))
 
-  expect_error(plot(cbass_fit, type = "obs.path", k.var = 3.5))
-  expect_error(plot(cbass_fit, type = "obs.path", k.var = 0))
-  expect_error(plot(cbass_fit, type = "obs.path", k.var = -1))
-  expect_error(plot(cbass_fit, type = "obs.path", k.var = NCOL(presidential_speech) + 1))
+  expect_error(plot(cbass_fit, type = "row.path", k.col = 3.5))
+  expect_error(plot(cbass_fit, type = "row.path", k.col = 0))
+  expect_error(plot(cbass_fit, type = "row.path", k.col = -1))
+  expect_error(plot(cbass_fit, type = "row.path", k.col = NCOL(presidential_speech) + 1))
 
   ## Error on unknown arguments
-  expect_error(plot(cbass_fit, type = "obs.path", 5))
-  expect_error(plot(cbass_fit, type = "obs.path", a = 5))
+  expect_error(plot(cbass_fit, type = "row.path", 5))
+  expect_error(plot(cbass_fit, type = "row.path", a = 5))
 })
 
-test_that("CBASS path plot works for variables", {
+test_that("CBASS path plot works for columns", {
   cbass_fit <- CBASS(presidential_speech)
 
   ## Main settings work
-  expect_no_error(plot(cbass_fit, type = "var.path", k.obs = 3))
-  expect_is(plot(cbass_fit, type = "var.path", k.obs  = 3), "gg")
+  expect_no_error(plot(cbass_fit, type = "col.path", k.row = 3))
+  expect_is(plot(cbass_fit, type = "col.path", k.row  = 3), "gg")
 
   ## Can only plot pre-calculated PCs right now
   ## FIXME -- See GH #24
-  expect_error(plot(cbass_fit, type = "var.path", k.obs  = 3, axis = c("amount", "appropri")))
-  expect_error(plot(cbass_fit, type = "var.path", k.obs  = 3, axis = c("PC1", "PC5")))
+  expect_error(plot(cbass_fit, type = "col.path", k.row  = 3, axis = c("amount", "appropri")))
+  expect_error(plot(cbass_fit, type = "col.path", k.row  = 3, axis = c("PC1", "PC5")))
 
-  ## Must give at most one of `percent`, `k.obs`, `k.var`
-  expect_error(plot(cbass_fit, type = "var.path", percent = 0.5, k.obs = 3))
-  expect_error(plot(cbass_fit, type = "var.path", percent = 0.5, k.var = 3))
-  expect_error(plot(cbass_fit, type = "var.path", k.obs = 3, k.var = 3))
+  ## Must give at most one of `percent`, `k.row`, `k.col`
+  expect_error(plot(cbass_fit, type = "col.path", percent = 0.5, k.row = 3))
+  expect_error(plot(cbass_fit, type = "col.path", percent = 0.5, k.col = 3))
+  expect_error(plot(cbass_fit, type = "col.path", k.row = 3, k.col = 3))
 
   ## Error checking on `percent` and `k`
-  expect_error(plot(cbass_fit, type = "var.path", percent = 1.5))
-  expect_error(plot(cbass_fit, type = "var.path", percent = -0.5))
-  expect_error(plot(cbass_fit, type = "var.path", percent = NA))
-  expect_error(plot(cbass_fit, type = "var.path", percent = c(0.25, 0.75)))
+  expect_error(plot(cbass_fit, type = "col.path", percent = 1.5))
+  expect_error(plot(cbass_fit, type = "col.path", percent = -0.5))
+  expect_error(plot(cbass_fit, type = "col.path", percent = NA))
+  expect_error(plot(cbass_fit, type = "col.path", percent = c(0.25, 0.75)))
 
-  expect_error(plot(cbass_fit, type = "var.path", k.obs = 3.5))
-  expect_error(plot(cbass_fit, type = "var.path", k.obs = 0))
-  expect_error(plot(cbass_fit, type = "var.path", k.obs = -1))
-  expect_error(plot(cbass_fit, type = "var.path", k.obs = NROW(presidential_speech) + 1))
+  expect_error(plot(cbass_fit, type = "col.path", k.row = 3.5))
+  expect_error(plot(cbass_fit, type = "col.path", k.row = 0))
+  expect_error(plot(cbass_fit, type = "col.path", k.row = -1))
+  expect_error(plot(cbass_fit, type = "col.path", k.row = NROW(presidential_speech) + 1))
 
-  expect_error(plot(cbass_fit, type = "var.path", k.var = 3.5))
-  expect_error(plot(cbass_fit, type = "var.path", k.var = 0))
-  expect_error(plot(cbass_fit, type = "var.path", k.var = -1))
-  expect_error(plot(cbass_fit, type = "var.path", k.var = NCOL(presidential_speech) + 1))
+  expect_error(plot(cbass_fit, type = "col.path", k.col = 3.5))
+  expect_error(plot(cbass_fit, type = "col.path", k.col = 0))
+  expect_error(plot(cbass_fit, type = "col.path", k.col = -1))
+  expect_error(plot(cbass_fit, type = "col.path", k.col = NCOL(presidential_speech) + 1))
 
   ## Error on unknown arguments
-  expect_error(plot(cbass_fit, type = "var.path", 5))
-  expect_error(plot(cbass_fit, type = "var.path", a = 5))
+  expect_error(plot(cbass_fit, type = "col.path", 5))
+  expect_error(plot(cbass_fit, type = "col.path", a = 5))
 })
 
-test_that("CBASS dendrogram plot works for observations", {
+test_that("CBASS dendrogram plot works for rows", {
   cbass_fit <- CBASS(presidential_speech)
 
   ## Main settings work
-  expect_no_error(plot(cbass_fit, type = "obs.dendrogram", k.obs = 3))
-  expect_equal(plot(cbass_fit, type = "obs.dendrogram", k.obs = 3), invisible(cbass_fit))
+  expect_no_error(plot(cbass_fit, type = "row.dendrogram", k.row = 3))
+  expect_equal(plot(cbass_fit, type = "row.dendrogram", k.row = 3), invisible(cbass_fit))
 
-  ## Must give at most one of `percent`, `k.obs`, `k.var`
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", percent = 0.5, k.obs = 3))
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", percent = 0.5, k.var = 3))
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", k.obs = 3, k.var = 3))
+  ## Must give at most one of `percent`, `k.row`, `k.col`
+  expect_error(plot(cbass_fit, type = "row.dendrogram", percent = 0.5, k.row = 3))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", percent = 0.5, k.col = 3))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", k.row = 3, k.col = 3))
 
-  ## Error checking on `percent`, `k.obs`, `k.var`
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", percent = 1.5))
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", percent = -0.5))
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", percent = NA))
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", percent = c(0.25, 0.75)))
+  ## Error checking on `percent`, `k.row`, `k.col`
+  expect_error(plot(cbass_fit, type = "row.dendrogram", percent = 1.5))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", percent = -0.5))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", percent = NA))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", percent = c(0.25, 0.75)))
 
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", k.obs = 3.5))
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", k.obs = 0))
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", k.obs = -1))
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", k.obs = NROW(presidential_speech) + 1))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", k.row = 3.5))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", k.row = 0))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", k.row = -1))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", k.row = NROW(presidential_speech) + 1))
 
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", k.var = 3.5))
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", k.var = 0))
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", k.var = -1))
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", k.var = NCOL(presidential_speech) + 1))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", k.col = 3.5))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", k.col = 0))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", k.col = -1))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", k.col = NCOL(presidential_speech) + 1))
 
   ## Error checking on two specially handled arguments
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", k.obs = 3, dend.branch.width = 0))
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", k.obs = 3, dend.branch.width = -2))
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", k.obs = 3, dend.labels.cex   = 0))
-  expect_error(plot(cbass_fit, type = "obs.dendrogram", k.obs = 3, dend.labels.cex   = -2))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", k.row = 3, dend.branch.width = 0))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", k.row = 3, dend.branch.width = -2))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", k.row = 3, dend.labels.cex   = 0))
+  expect_error(plot(cbass_fit, type = "row.dendrogram", k.row = 3, dend.labels.cex   = -2))
 })
 
-test_that("CBASS dendrogram plot works for observations", {
+test_that("CBASS dendrogram plot works for columns", {
   cbass_fit <- CBASS(presidential_speech)
 
   ## Main settings work
-  expect_no_error(plot(cbass_fit, type = "var.dendrogram", k.obs = 3))
-  expect_equal(plot(cbass_fit, type = "var.dendrogram", k.obs = 3), invisible(cbass_fit))
+  expect_no_error(plot(cbass_fit, type = "col.dendrogram", k.row = 3))
+  expect_equal(plot(cbass_fit, type = "col.dendrogram", k.row = 3), invisible(cbass_fit))
 
-  ## Must give at most one of `percent`, `k.obs`, `k.var`
-  expect_error(plot(cbass_fit, type = "var.dendrogram", percent = 0.5, k.obs = 3))
-  expect_error(plot(cbass_fit, type = "var.dendrogram", percent = 0.5, k.var = 3))
-  expect_error(plot(cbass_fit, type = "var.dendrogram", k.obs = 3, k.var = 3))
+  ## Must give at most one of `percent`, `k.row`, `k.col`
+  expect_error(plot(cbass_fit, type = "col.dendrogram", percent = 0.5, k.row = 3))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", percent = 0.5, k.col = 3))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", k.row = 3, k.col = 3))
 
-  ## Error checking on `percent`, `k.obs`, `k.var`
-  expect_error(plot(cbass_fit, type = "var.dendrogram", percent = 1.5))
-  expect_error(plot(cbass_fit, type = "var.dendrogram", percent = -0.5))
-  expect_error(plot(cbass_fit, type = "var.dendrogram", percent = NA))
-  expect_error(plot(cbass_fit, type = "var.dendrogram", percent = c(0.25, 0.75)))
+  ## Error checking on `percent`, `k.row`, `k.col`
+  expect_error(plot(cbass_fit, type = "col.dendrogram", percent = 1.5))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", percent = -0.5))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", percent = NA))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", percent = c(0.25, 0.75)))
 
-  expect_error(plot(cbass_fit, type = "var.dendrogram", k.obs = 3.5))
-  expect_error(plot(cbass_fit, type = "var.dendrogram", k.obs = 0))
-  expect_error(plot(cbass_fit, type = "var.dendrogram", k.obs = -1))
-  expect_error(plot(cbass_fit, type = "var.dendrogram", k.obs = NROW(presidential_speech) + 1))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", k.row = 3.5))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", k.row = 0))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", k.row = -1))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", k.row = NROW(presidential_speech) + 1))
 
-  expect_error(plot(cbass_fit, type = "var.dendrogram", k.var = 3.5))
-  expect_error(plot(cbass_fit, type = "var.dendrogram", k.var = 0))
-  expect_error(plot(cbass_fit, type = "var.dendrogram", k.var = -1))
-  expect_error(plot(cbass_fit, type = "var.dendrogram", k.var = NCOL(presidential_speech) + 1))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", k.col = 3.5))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", k.col = 0))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", k.col = -1))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", k.col = NCOL(presidential_speech) + 1))
 
   ## Error checking on two specially handled arguments
-  expect_error(plot(cbass_fit, type = "var.dendrogram", k.obs = 3, dend.branch.width = 0))
-  expect_error(plot(cbass_fit, type = "var.dendrogram", k.obs = 3, dend.branch.width = -2))
-  expect_error(plot(cbass_fit, type = "var.dendrogram", k.obs = 3, dend.labels.cex   = 0))
-  expect_error(plot(cbass_fit, type = "var.dendrogram", k.obs = 3, dend.labels.cex   = -2))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", k.row = 3, dend.branch.width = 0))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", k.row = 3, dend.branch.width = -2))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", k.row = 3, dend.labels.cex   = 0))
+  expect_error(plot(cbass_fit, type = "col.dendrogram", k.row = 3, dend.labels.cex   = -2))
 })
 
 test_that("CBASS heatmap plot works", {
@@ -158,30 +158,30 @@ test_that("CBASS heatmap plot works", {
   expect_no_error(plot(cbass_fit, type = "heatmap"))
   expect_equal(plot(cbass_fit, type = "heatmap"), invisible(cbass_fit))
   expect_equal(plot(cbass_fit, type = "heatmap", percent = 0.5), invisible(cbass_fit))
-  expect_equal(plot(cbass_fit, type = "heatmap", k.obs = 5), invisible(cbass_fit))
-  expect_equal(plot(cbass_fit, type = "heatmap", k.var = 5), invisible(cbass_fit))
+  expect_equal(plot(cbass_fit, type = "heatmap", k.row = 5), invisible(cbass_fit))
+  expect_equal(plot(cbass_fit, type = "heatmap", k.col = 5), invisible(cbass_fit))
 
-  ## Must give at most one of `percent`, `k.obs`, `k.var`
-  expect_error(plot(cbass_fit, type = "heatmap", percent = 0.5, k.obs = 3))
-  expect_error(plot(cbass_fit, type = "heatmap", percent = 0.5, k.var = 3))
-  expect_error(plot(cbass_fit, type = "heatmap", k.obs = 3, k.var = 3))
-  expect_error(plot(cbass_fit, type = "heatmap", k.obs = 3, k.var = 3, percent = 0.5))
+  ## Must give at most one of `percent`, `k.row`, `k.col`
+  expect_error(plot(cbass_fit, type = "heatmap", percent = 0.5, k.row = 3))
+  expect_error(plot(cbass_fit, type = "heatmap", percent = 0.5, k.col = 3))
+  expect_error(plot(cbass_fit, type = "heatmap", k.row = 3, k.col = 3))
+  expect_error(plot(cbass_fit, type = "heatmap", k.row = 3, k.col = 3, percent = 0.5))
 
-  ## Error checking on `percent`, `k.obs`, `k.var`
+  ## Error checking on `percent`, `k.row`, `k.col`
   expect_error(plot(cbass_fit, type = "heatmap", percent = 1.5))
   expect_error(plot(cbass_fit, type = "heatmap", percent = -0.5))
   expect_error(plot(cbass_fit, type = "heatmap", percent = NA))
   expect_error(plot(cbass_fit, type = "heatmap", percent = c(0.25, 0.75)))
 
-  expect_error(plot(cbass_fit, type = "heatmap", k.obs = 3.5))
-  expect_error(plot(cbass_fit, type = "heatmap", k.obs = 0))
-  expect_error(plot(cbass_fit, type = "heatmap", k.obs = -1))
-  expect_error(plot(cbass_fit, type = "heatmap", k.obs = NROW(presidential_speech) + 1))
+  expect_error(plot(cbass_fit, type = "heatmap", k.row = 3.5))
+  expect_error(plot(cbass_fit, type = "heatmap", k.row = 0))
+  expect_error(plot(cbass_fit, type = "heatmap", k.row = -1))
+  expect_error(plot(cbass_fit, type = "heatmap", k.row = NROW(presidential_speech) + 1))
 
-  expect_error(plot(cbass_fit, type = "heatmap", k.var = 3.5))
-  expect_error(plot(cbass_fit, type = "heatmap", k.var = 0))
-  expect_error(plot(cbass_fit, type = "heatmap", k.var = -1))
-  expect_error(plot(cbass_fit, type = "heatmap", k.var = NCOL(presidential_speech) + 1))
+  expect_error(plot(cbass_fit, type = "heatmap", k.col = 3.5))
+  expect_error(plot(cbass_fit, type = "heatmap", k.col = 0))
+  expect_error(plot(cbass_fit, type = "heatmap", k.col = -1))
+  expect_error(plot(cbass_fit, type = "heatmap", k.col = NCOL(presidential_speech) + 1))
 
   ## Error checking on two specially handled arguments
   expect_error(plot(cbass_fit, type = "heatmap", heatcol.label.cex = 0))

--- a/tests/testthat/test_cbass_print.R
+++ b/tests/testthat/test_cbass_print.R
@@ -5,8 +5,8 @@ test_that("print.CBASS works for default settings", {
   cbass_print <- capture_print(cbass_fit)
 
   expect_str_contains(cbass_print, "Algorithm:[ ]+CBASS-VIZ")
-  expect_str_contains(cbass_print, "Number of Observations:[ ]+44")
-  expect_str_contains(cbass_print, "Number of Variables:[ ]+75")
+  expect_str_contains(cbass_print, "Number of Rows:[ ]+44")
+  expect_str_contains(cbass_print, "Number of Columns:[ ]+75")
   expect_str_contains(cbass_print, "Global centering:[ ]+TRUE")
   expect_str_contains(cbass_print, "Source: Radial Basis Function Kernel Weights")
   expect_str_contains(cbass_print, "Distance Metric: Euclidean")

--- a/tests/testthat/test_cbass_sparsity_pattern.R
+++ b/tests/testthat/test_cbass_sparsity_pattern.R
@@ -1,140 +1,53 @@
-context("test CBASS sparsity pattern")
+context("Test CBASS Sparsity Invariants")
 
-
-
-test_that("CBASS-returned observation sparsity pattern begins with no fusions",{
-  cbass.fit <- CBASS(presidential_speech, alg.type = 'cbass')
-  expect_equal(
-    sum(cbass.fit$cbass.sol.path$v.col.zero.inds[, 1]),
-    0
-  )
-})
-test_that("CBASS-returned observation sparsity pattern ends with full fusions",{
-  cbass.fit <- CBASS(presidential_speech, alg.type = 'cbass')
-  expect_true(
-    all(cbass.fit$cbass.sol.path$v.col.zero.inds[, ncol(cbass.fit$cbass.sol.path$v.col.zero.inds)] == 1)
-  )
-})
-test_that("CBASS-returned variable sparsity pattern begins with no fusions",{
-  cbass.fit <- CBASS(presidential_speech, alg.type = 'cbass')
-  expect_equal(
-    sum(cbass.fit$cbass.sol.path$v.row.zero.inds[, 1]),
-    0
-  )
-})
-test_that("CBASS-returned variable sparsity pattern ends with full fusions",{
-  cbass.fit <- CBASS(presidential_speech, alg.type='cbass')
-  expect_true(
-    all(cbass.fit$cbass.sol.path$v.row.zero.inds[, ncol(cbass.fit$cbass.sol.path$v.row.zero.inds)] == 1)
-  )
+test_that("CBASS begins with no fusions", {
+  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbass')
+  expect_zeros(cbass_fit$cbass.sol.path$v.col.zero.inds[, 1])
+  expect_zeros(cbass_fit$cbass.sol.path$v.row.zero.inds[, 1])
 })
 
-
-
-
-
-
-test_that("CBASSVIZ-returned observation sparsity pattern begins with no fusions",{
-  cbass.fit <- CBASS(presidential_speech, alg.type = 'cbassviz')
-  expect_equal(
-    sum(cbass.fit$cbass.sol.path$v.col.zero.inds[, 1]),
-    0
-  )
-})
-test_that("CBASSVIZ-returned observation sparsity pattern ends with full fusions",{
-  cbass.fit <- CBASS(presidential_speech, alg.type = 'cbassviz')
-  expect_true(
-    all(cbass.fit$cbass.sol.path$v.col.zero.inds[, ncol(cbass.fit$cbass.sol.path$v.col.zero.inds)]==1)
-  )
-})
-test_that("CBASSVIZ-returned variable sparsity pattern begins with no fusions",{
-  cbass.fit <- CBASS(presidential_speech, alg.type = 'cbassviz')
-  expect_equal(
-    sum(cbass.fit$cbass.sol.path$v.row.zero.inds[, 1]),
-    0
-  )
-})
-test_that("CBASSVIZ-returned variable sparsity pattern ends with full fusions",{
-  cbass.fit <- CBASS(presidential_speech, alg.type='cbassviz')
-  expect_true(
-    all(cbass.fit$cbass.sol.path$v.row.zero.inds[, ncol(cbass.fit$cbass.sol.path$v.row.zero.inds)] == 1)
-  )
+test_that("CBASS ends with full fusions", {
+  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbass')
+  expect_ones(cbass_fit$cbass.sol.path$v.col.zero.inds[, NCOL(cbass_fit$cbass.sol.path$v.col.zero.inds)])
+  expect_ones(cbass_fit$cbass.sol.path$v.row.zero.inds[, NCOL(cbass_fit$cbass.sol.path$v.row.zero.inds)])
 })
 
-
-
-
-
-test_that("CBASS-returned observation sparsity pattern begins with no fusions (uniform weights)",{
-  weight_mat_obs <-matrix(1, nrow=nrow(presidential_speech), ncol=nrow(presidential_speech))
-  weight_mat_var <-matrix(1, nrow=ncol(presidential_speech), ncol=ncol(presidential_speech))
-  cbass.fit <- CBASS(presidential_speech, alg.type = 'cbass', obs_weights = weight_mat_obs, var_weights = weight_mat_var)
-  expect_equal(
-    sum(cbass.fit$cbass.sol.path$v.col.zero.inds[, 1]),
-    0
-  )
-})
-test_that("CBASS-returned observation sparsity pattern ends with full fusions (uniform weights)",{
-  weight_mat_obs <-matrix(1, nrow=nrow(presidential_speech), ncol=nrow(presidential_speech))
-  weight_mat_var <-matrix(1, nrow=ncol(presidential_speech), ncol=ncol(presidential_speech))
-  cbass.fit <- CBASS(presidential_speech, alg.type = 'cbass', obs_weights = weight_mat_obs, var_weights = weight_mat_var)
-  expect_true(
-    all(cbass.fit$cbass.sol.path$v.col.zero.inds[, ncol(cbass.fit$cbass.sol.path$v.col.zero.inds)] == 1)
-  )
-})
-test_that("CBASS-returned variable sparsity pattern begins with no fusions (uniform weights)",{
-  weight_mat_obs <-matrix(1, nrow=nrow(presidential_speech), ncol=nrow(presidential_speech))
-  weight_mat_var <-matrix(1, nrow=ncol(presidential_speech), ncol=ncol(presidential_speech))
-  cbass.fit <- CBASS(presidential_speech, alg.type = 'cbass', obs_weights = weight_mat_obs, var_weights = weight_mat_var)
-  expect_equal(
-    sum(cbass.fit$cbass.sol.path$v.row.zero.inds[, 1]),
-    0
-  )
-})
-test_that("CBASS-returned variable sparsity pattern ends with full fusions (uniform weights)",{
-  weight_mat_obs <-matrix(1, nrow=nrow(presidential_speech), ncol=nrow(presidential_speech))
-  weight_mat_var <-matrix(1, nrow=ncol(presidential_speech), ncol=ncol(presidential_speech))
-  cbass.fit <- CBASS(presidential_speech, alg.type = 'cbass', obs_weights = weight_mat_obs, var_weights = weight_mat_var)
-  expect_true(
-    all(cbass.fit$cbass.sol.path$v.row.zero.inds[, ncol(cbass.fit$cbass.sol.path$v.row.zero.inds)]==1)
-  )
+test_that("CBASS-VIZ begins with no fusions", {
+  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbassviz')
+  expect_zeros(cbass_fit$cbass.sol.path$v.col.zero.inds[, 1])
+  expect_zeros(cbass_fit$cbass.sol.path$v.row.zero.inds[, 1])
 })
 
-
-
-
-test_that("CBASSVIZ-returned observation sparsity pattern begins with no fusions (uniform weights)",{
-  weight_mat_obs <-matrix(1, nrow=nrow(presidential_speech), ncol=nrow(presidential_speech))
-  weight_mat_var <-matrix(1, nrow=ncol(presidential_speech), ncol=ncol(presidential_speech))
-  cbass.fit <- CBASS(presidential_speech, alg.type = 'cbassviz', obs_weights = weight_mat_obs, var_weights = weight_mat_var)
-  expect_equal(
-    sum(cbass.fit$cbass.sol.path$v.col.zero.inds[, 1]),
-    0
-  )
-})
-test_that("CBASSVIZ-returned observation sparsity pattern ends with full fusions (uniform weights)",{
-  weight_mat_obs <-matrix(1, nrow=nrow(presidential_speech), ncol=nrow(presidential_speech))
-  weight_mat_var <-matrix(1, nrow=ncol(presidential_speech), ncol=ncol(presidential_speech))
-  cbass.fit <- CBASS(presidential_speech, alg.type = 'cbassviz', obs_weights = weight_mat_obs, var_weights = weight_mat_var)
-  expect_true(
-    all(cbass.fit$cbass.sol.path$v.col.zero.inds[, ncol(cbass.fit$cbass.sol.path$v.col.zero.inds)] == 1)
-  )
-})
-test_that("CBASSVIZ-returned variable sparsity pattern begins with no fusions (uniform weights)",{
-  weight_mat_obs <-matrix(1, nrow=nrow(presidential_speech), ncol=nrow(presidential_speech))
-  weight_mat_var <-matrix(1, nrow=ncol(presidential_speech), ncol=ncol(presidential_speech))
-  cbass.fit <- CBASS(presidential_speech, alg.type = 'cbassviz', obs_weights = weight_mat_obs, var_weights = weight_mat_var)
-  expect_equal(
-    sum(cbass.fit$cbass.sol.path$v.row.zero.inds[, 1]),
-    0
-  )
-})
-test_that("CBASSVIZ-returned variable sparsity pattern ends with full fusions (uniform weights)",{
-  weight_mat_obs <-matrix(1, nrow=nrow(presidential_speech), ncol=nrow(presidential_speech))
-  weight_mat_var <-matrix(1, nrow=ncol(presidential_speech), ncol=ncol(presidential_speech))
-  cbass.fit <- CBASS(presidential_speech, alg.type = 'cbassviz', obs_weights = weight_mat_obs, var_weights = weight_mat_var)
-  expect_true(
-    all(cbass.fit$cbass.sol.path$v.row.zero.inds[, ncol(cbass.fit$cbass.sol.path$v.row.zero.inds)]==1)
-  )
+test_that("CBASS-VIZ ends with full fusions", {
+  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbassviz')
+  expect_ones(cbass_fit$cbass.sol.path$v.col.zero.inds[, NCOL(cbass_fit$cbass.sol.path$v.col.zero.inds)])
+  expect_ones(cbass_fit$cbass.sol.path$v.row.zero.inds[, NCOL(cbass_fit$cbass.sol.path$v.row.zero.inds)])
 })
 
+test_that("CBASS begins with no fusions (uniform weights)", {
+  uniform_weights <- function(X) matrix(1, nrow = NROW(X), ncol = NROW(X))
+  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbass', row_weights = uniform_weights, col_weights = uniform_weights)
+  expect_zeros(cbass_fit$cbass.sol.path$v.col.zero.inds[, 1])
+  expect_zeros(cbass_fit$cbass.sol.path$v.row.zero.inds[, 1])
+})
+
+test_that("CBASS ends with full fusions (uniform weights)", {
+  uniform_weights <- function(X) matrix(1, nrow = NROW(X), ncol = NROW(X))
+  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbass', row_weights = uniform_weights, col_weights = uniform_weights)
+  expect_ones(cbass_fit$cbass.sol.path$v.col.zero.inds[, NCOL(cbass_fit$cbass.sol.path$v.col.zero.inds)])
+  expect_ones(cbass_fit$cbass.sol.path$v.row.zero.inds[, NCOL(cbass_fit$cbass.sol.path$v.row.zero.inds)])
+})
+
+test_that("CBASS-VIZ begins with no fusions (uniform weights)", {
+  uniform_weights <- function(X) matrix(1, nrow = NROW(X), ncol = NROW(X))
+  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbassviz', row_weights = uniform_weights, col_weights = uniform_weights)
+  expect_zeros(cbass_fit$cbass.sol.path$v.col.zero.inds[, 1])
+  expect_zeros(cbass_fit$cbass.sol.path$v.row.zero.inds[, 1])
+})
+
+test_that("CBASS-VIZ ends with full fusions (uniform weights)", {
+  uniform_weights <- function(X) matrix(1, nrow = NROW(X), ncol = NROW(X))
+  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbassviz', row_weights = uniform_weights, col_weights = uniform_weights)
+  expect_ones(cbass_fit$cbass.sol.path$v.col.zero.inds[, NCOL(cbass_fit$cbass.sol.path$v.col.zero.inds)])
+  expect_ones(cbass_fit$cbass.sol.path$v.row.zero.inds[, NCOL(cbass_fit$cbass.sol.path$v.row.zero.inds)])
+})

--- a/tests/testthat/test_cbass_weights.R
+++ b/tests/testthat/test_cbass_weights.R
@@ -1,10 +1,10 @@
 context("Test CBASS Weight Handling")
 
-## Tests for observation weights
-test_that("CBASS works with user weight function for observation weights", {
+## Tests for row weights
+test_that("CBASS works with user weight function for row weights", {
   # FIXME: This should work - see GitHub #8
   ## uniform_weight_func <- function(X) matrix(1, nrow=NROW(X), ncol=NROW(X))
-  ## CBASS(presidential_speech, obs_weights = uniform_weight_func)
+  ## CBASS(presidential_speech, row_weights = uniform_weight_func)
 
   # By manual testing, this is a good weight function / matrix
   my_weight_func <- function(X) {
@@ -15,35 +15,35 @@ test_that("CBASS works with user weight function for observation weights", {
   }
 
   expect_true(clustRviz:::is_connected_adj_mat(my_weight_func(presidential_speech)))
-  expect_no_error(CBASS(presidential_speech, obs_weights = my_weight_func))
+  expect_no_error(CBASS(presidential_speech, row_weights = my_weight_func))
 })
 
-test_that("CBASS works with user weight matrix for observation weights", {
+test_that("CBASS works with user weight matrix for row weights", {
   mat <- exp(-0.01 * as.matrix(dist(presidential_speech))^2)
   diag(mat) <- 0
   mat[mat < quantile(mat, 0.73)] <- 0
-  expect_no_error(CBASS(presidential_speech, obs_weights = mat))
+  expect_no_error(CBASS(presidential_speech, row_weights = mat))
 })
 
-test_that("CBASS errors with negative weights for observation weights", {
+test_that("CBASS errors with negative weights for row weights", {
   mat <- -1 * exp(-0.01 * as.matrix(dist(presidential_speech))^2)
   diag(mat) <- 0
   mat[mat < quantile(mat, 0.73)] <- 0
-  expect_error(CBASS(presidential_speech, obs_weights = mat))
+  expect_error(CBASS(presidential_speech, row_weights = mat))
 })
 
-test_that("CBASS errors with unconnected graphs for observation weights", {
+test_that("CBASS errors with unconnected graphs for row weights", {
   mat <- exp(-0.01 * as.matrix(dist(presidential_speech))^2)
   diag(mat) <- 0
   mat[mat < quantile(mat, 0.95)] <- 0
-  expect_error(CBASS(presidential_speech, obs_weights = mat))
+  expect_error(CBASS(presidential_speech, row_weights = mat))
 })
 
-## Tests for variable / feature weights
-test_that("CBASS works with user weight function for variable weights", {
+## Tests for column / feature weights
+test_that("CBASS works with user weight function for column weights", {
   # FIXME: This should work - see GitHub #8
   ## uniform_weight_func <- function(X) matrix(1, nrow=NROW(X), ncol=NROW(X))
-  ## CBASS(presidential_speech, var_weights = uniform_weight_func)
+  ## CBASS(presidential_speech, col_weights = uniform_weight_func)
 
   # By manual testing, this is a good weight function / matrix
   my_weight_func <- function(X) {
@@ -54,26 +54,26 @@ test_that("CBASS works with user weight function for variable weights", {
   }
 
   expect_true(clustRviz:::is_connected_adj_mat(my_weight_func(t(presidential_speech))))
-  expect_no_error(CBASS(presidential_speech, var_weights = my_weight_func))
+  expect_no_error(CBASS(presidential_speech, col_weights = my_weight_func))
 })
 
-test_that("CBASS works with user weight matrix for variable weights", {
+test_that("CBASS works with user weight matrix for column weights", {
   mat <- exp(-0.01 * as.matrix(dist(t(presidential_speech)))^2)
   diag(mat) <- 0
   mat[mat < quantile(mat, 0.73)] <- 0
-  expect_no_error(CBASS(presidential_speech, var_weights = mat))
+  expect_no_error(CBASS(presidential_speech, col_weights = mat))
 })
 
-test_that("CBASS errors with negative weights for variable weights", {
+test_that("CBASS errors with negative weights for column weights", {
   mat <- -1 * exp(-0.01 * as.matrix(dist(t(presidential_speech)))^2)
   diag(mat) <- 0
   mat[mat < quantile(mat, 0.73)] <- 0
-  expect_error(CBASS(presidential_speech, var_weights = mat))
+  expect_error(CBASS(presidential_speech, col_weights = mat))
 })
 
-test_that("CBASS errors with unconnected graphs for variable weights", {
+test_that("CBASS errors with unconnected graphs for column weights", {
   mat <- exp(-0.01 * as.matrix(dist(t(presidential_speech)))^2)
   diag(mat) <- 0
   mat[mat < quantile(mat, 0.95)] <- 0
-  expect_error(CBASS(presidential_speech, var_weights = mat))
+  expect_error(CBASS(presidential_speech, col_weights = mat))
 })

--- a/tests/testthat/test_matrix_prox.R
+++ b/tests/testthat/test_matrix_prox.R
@@ -1,0 +1,60 @@
+context("Test C++ matrix prox")
+
+test_that("L1 matrix prox works", {
+  set.seed(125)
+  n <- 25
+  p <- 50
+
+  X <- matrix(rnorm(n * p), nrow = n, ncol = p)
+
+  MatrixProx <- clustRviz:::MatrixProx
+  weights <- rep(1, n)
+
+  expect_equal(X, MatrixProx(X, lambda = 0, weights = weights, l1 = TRUE))
+  expect_equal(abs(X) + 4, MatrixProx(abs(X) + 5, lambda = 1, weights = weights, l1 = TRUE))
+  expect_equal(-abs(X) - 4, MatrixProx(-abs(X) - 5, lambda = 1, weights = weights, l1 = TRUE))
+
+  ## Now we check that weights work
+  X <- matrix(1:25, nrow = 25, ncol = 1)
+  weights <- 1:25
+  expect_equal(matrix(0, nrow = 25, ncol = 1),
+               MatrixProx(X, lambda = 1, weights = weights, l1 = TRUE))
+
+  X <- matrix(5, nrow = 6, ncol = 1)
+  weights <- seq(0, 5)
+  expect_equal(matrix(5 - weights, nrow = 6, ncol = 1),
+               MatrixProx(X, lambda = 1, weights = weights, l1 = TRUE))
+})
+
+test_that("L2 prox works", {
+  set.seed(125)
+  MatrixProx <- clustRviz:::MatrixProx
+  num_unique_cols <- clustRviz:::num_unique_cols
+  n <- 25
+
+  ## If X has a single column, same as L1 prox
+  X <- matrix(rnorm(n, sd = 3), ncol = 1)
+  weights <- rexp(n)
+
+  expect_equal(MatrixProx(X, lambda = 1, weights = weights, l1 = TRUE),
+               MatrixProx(X, lambda = 1, weights = weights, l1 = FALSE))
+
+  p <- 5
+  X <- matrix(1, nrow = n, ncol = p)
+  weights <- seq(0, 5, length.out = 25)
+
+  expect_equal(1, num_unique_cols(MatrixProx(X, lambda = 1, weights = weights, l1 = FALSE)))
+
+  y <- matrix(c(3, 4), nrow = 1)
+
+  expect_equal(MatrixProx(y, 1, 1, l1 = FALSE), y * (1 - 1/5))
+  expect_equal(MatrixProx(y, 1, 3, l1 = FALSE), y * (1 - 3/5))
+  expect_equal(MatrixProx(y, 2, 1, l1 = FALSE), y * (1 - 2/5))
+  expect_equal(MatrixProx(y, 2, 3, l1 = FALSE), y * 0)
+
+  y <- -1 * y
+  expect_equal(MatrixProx(y, 1, 1, l1 = FALSE), y * (1 - 1/5))
+  expect_equal(MatrixProx(y, 1, 3, l1 = FALSE), y * (1 - 3/5))
+  expect_equal(MatrixProx(y, 2, 1, l1 = FALSE), y * (1 - 2/5))
+  expect_equal(MatrixProx(y, 2, 3, l1 = FALSE), y * 0)
+})

--- a/tests/testthat/test_options.R
+++ b/tests/testthat/test_options.R
@@ -1,0 +1,101 @@
+context("Options Handling")
+
+test_that("Test option error handling", {
+  ## ADMM relaxation parameter
+  expect_error(clustRviz_options(rho = 0))
+  expect_error(clustRviz_options(rho = -1))
+  expect_error(clustRviz_options(rho = "a"))
+  expect_error(clustRviz_options(rho = NA))
+  expect_error(clustRviz_options(rho = c(1, 2)))
+
+  ## Initial (burn-in phase) regularization parameter
+  expect_error(clustRviz_options(epsilon = 0))
+  expect_error(clustRviz_options(epsilon = -1))
+  expect_error(clustRviz_options(epsilon = "a"))
+  expect_error(clustRviz_options(epsilon = NA))
+  expect_error(clustRviz_options(epsilon = c(1, 2)))
+
+  ## Back-tracking parameters
+  expect_error(clustRviz_options(viz_initial_step = 1))
+  expect_error(clustRviz_options(viz_initial_step = 0.5))
+  expect_error(clustRviz_options(viz_initial_step = 0))
+  expect_error(clustRviz_options(viz_initial_step = -1))
+  expect_error(clustRviz_options(viz_initial_step = -1.5))
+  expect_error(clustRviz_options(viz_initial_step = "a"))
+  expect_error(clustRviz_options(viz_initial_step = NA))
+  expect_error(clustRviz_options(viz_initial_step = c(1.5, 2)))
+
+  expect_error(clustRviz_options(viz_small_step = 1))
+  expect_error(clustRviz_options(viz_small_step = 0.5))
+  expect_error(clustRviz_options(viz_small_step = 0))
+  expect_error(clustRviz_options(viz_small_step = -1))
+  expect_error(clustRviz_options(viz_small_step = -1.5))
+  expect_error(clustRviz_options(viz_small_step = "a"))
+  expect_error(clustRviz_options(viz_small_step = NA))
+  expect_error(clustRviz_options(viz_small_step = c(1.5, 2)))
+
+  expect_error(clustRviz_options(viz_max_inner_iter = 0))
+  expect_error(clustRviz_options(viz_max_inner_iter = -5))
+  expect_error(clustRviz_options(viz_max_inner_iter = 35.5))
+  expect_error(clustRviz_options(viz_max_inner_iter = "a"))
+  expect_error(clustRviz_options(viz_max_inner_iter = NA))
+  expect_error(clustRviz_options(viz_max_inner_iter = c(500, 600)))
+
+  # Stopping and storage parameters
+  expect_error(clustRviz_options(max_iter = 0))
+  expect_error(clustRviz_options(max_iter = -5))
+  expect_error(clustRviz_options(max_iter = 35.5))
+  expect_error(clustRviz_options(max_iter = "a"))
+  expect_error(clustRviz_options(max_iter = NA))
+  expect_error(clustRviz_options(max_iter = c(500, 600)))
+
+  expect_error(clustRviz_options(burn_in = 0))
+  expect_error(clustRviz_options(burn_in = -5))
+  expect_error(clustRviz_options(burn_in = 35.5))
+  expect_error(clustRviz_options(burn_in = "a"))
+  expect_error(clustRviz_options(burn_in = NA))
+  expect_error(clustRviz_options(burn_in = c(500, 600)))
+
+  expect_error(clustRviz_options(keep = 0))
+  expect_error(clustRviz_options(keep = -5))
+  expect_error(clustRviz_options(keep = 35.5))
+  expect_error(clustRviz_options(keep = "a"))
+  expect_error(clustRviz_options(keep = NA))
+  expect_error(clustRviz_options(keep = c(500, 600)))
+})
+
+test_that("clustRviz_reset_options works", {
+  base_opts <- clustRviz_options()
+
+  clustRviz_options(rho = 2, keep = 5, max_iter = 500, burn_in = 20)
+  expect_false(isTRUE(all.equal(base_opts, clustRviz_options())))
+
+  clustRviz_reset_options()
+  expect_equal(base_opts, clustRviz_options())
+})
+
+test_that("Setting clustRviz options works", {
+  clustRviz_options(rho = 2)
+  expect_equal(clustRviz:::.clustRvizOptionsEnv[["rho"]], 2)
+
+  clustRviz_options(viz_initial_step = 2)
+  expect_equal(clustRviz:::.clustRvizOptionsEnv[["viz_initial_step"]], 2)
+
+  clustRviz_options(viz_max_inner_iter = 20)
+  expect_equal(clustRviz:::.clustRvizOptionsEnv[["viz_max_inner_iter"]], 20)
+
+  clustRviz_options(viz_small_step = 1.2)
+  expect_equal(clustRviz:::.clustRvizOptionsEnv[["viz_small_step"]], 1.2)
+
+  clustRviz_reset_options()
+})
+
+test_that("Options warnings work", {
+  expect_warning(clustRviz_options(viz_initial_step = 1.2, viz_small_step = 1.2))
+  expect_warning(clustRviz_options(viz_initial_step = 1.2, viz_small_step = 2))
+
+  expect_warning(clustRviz_options(max_iter = 100, burn_in = 100))
+  expect_warning(clustRviz_options(max_iter = 100, burn_in = 150))
+
+  clustRviz_reset_options()
+})

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -8,10 +8,12 @@ capitalize_string <- function(x){
 }
 
 test_that("Validators work", {
-  is_logical_scalar <- clustRviz:::is_logical_scalar
-  is_numeric_scalar <- clustRviz:::is_numeric_scalar
-  is_integer_scalar <- clustRviz:::is_integer_scalar
-  is_percent_scalar <- clustRviz:::is_percent_scalar
+  is_logical_scalar  <- clustRviz:::is_logical_scalar
+  is_numeric_scalar  <- clustRviz:::is_numeric_scalar
+  is_integer_scalar  <- clustRviz:::is_integer_scalar
+  is_percent_scalar  <- clustRviz:::is_percent_scalar
+  is_positive_scalar <- clustRviz:::is_positive_scalar
+  is_positive_integer_scalar <- clustRviz:::is_positive_integer_scalar
 
   expect_true(is_logical_scalar(TRUE))
   expect_true(is_logical_scalar(FALSE))
@@ -44,6 +46,23 @@ test_that("Validators work", {
   expect_false(is_percent_scalar(NA))
   expect_false(is_percent_scalar(c(0.2, 0.5)))
   expect_false(is_percent_scalar("a"))
+
+  expect_true(is_positive_scalar(0.3))
+  expect_true(is_positive_scalar(1))
+  expect_false(is_positive_scalar(0))
+  expect_true(is_positive_scalar(1.5))
+  expect_false(is_positive_scalar(-1.5))
+  expect_false(is_positive_scalar(NA))
+  expect_false(is_positive_scalar(c(0.2, 0.5)))
+  expect_false(is_positive_scalar("a"))
+
+  expect_true(is_positive_integer_scalar(3))
+  expect_false(is_positive_integer_scalar(3.5))
+  expect_false(is_positive_integer_scalar(0))
+  expect_false(is_positive_integer_scalar(-4))
+  expect_false(is_positive_integer_scalar(NA))
+  expect_false(is_positive_integer_scalar(c(2, 5)))
+  expect_false(is_positive_integer_scalar("a"))
 
   is_square <- clustRviz:::is_square
   expect_true(is_square(matrix(1, 5, 5)))

--- a/vignettes/ClustRVizAlgorithm.Rmd
+++ b/vignettes/ClustRVizAlgorithm.Rmd
@@ -1,0 +1,251 @@
+---
+title: "`clustRviz` Computational Details"
+author:
+ - name: Michael Weylandt
+   affiliation: Department of Statistics, Rice University
+   email: michael.weylandt@rice.edu
+ - name: John Nagorski
+   affiliation: Department of Statistics, Rice University
+ - name: Genevera I. Allen
+   affiliation: | 
+     | Departments of Statistics, Computer Science, and Electical and Computer Engineering, Rice University
+     | Jan and Dan Duncan Neurological Research Institute, Baylor College of Medicine
+   email: gallen@rice.edu
+date: "Last Updated: September 29, 2018"
+output:
+  html_document:
+    toc: true
+    toc_float:
+      collapsed: false
+bibliography: vignettes.bib
+vignette: >
+  %\VignetteIndexEntry{Computational Details of the CARP and CBASS Algorithms}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+## Convex Clustering
+
+`CARP` begins with the convex clustering problem originally posed by 
+Hocking *et al.* [-@Hocking:2011]:^[Here, we consider the case of uniform weights
+to simplify some of the notation, but the general case is essentially the same.
+The general formulation of `CARP` is given below.]
+
+\[\text{arg min}_{U} \frac{1}{2}\|U - X\|_F^2 + \lambda\sum_{(i, j) \in \mathcal{E}} \|U_{i\cdot} - U_{j\cdot}\|_q\]
+
+Note that the second term can be written as $\|DU\|_{q, 1} = \sum_l \|(DU)_{l\cdot}\|_q$
+where 
+
+\[D_{l\cdot} \text{ is a vector of zeros except having a 1 where edge $l$ starts and a $-1$ where it ends} \]
+
+giving the problem 
+
+\[\text{arg min}_{U} \frac{1}{2}\|U - X\|_F^2 + \lambda\|DU\|_q\]
+
+As noted by Chi and Lange [-@Chi:2015], this formulation suggests the use of an
+operator splitting method. We consider an ADMM algorithm [@Boyd:2011], beginning
+by introducing a copy variable $V = DU$ to reformulate the problem as:
+
+\[\text{arg min}_{U} \frac{1}{2}\|U - X\|_F^2 + \lambda\|V\|_{q, 1} \text{ subject to } DU - V = 0\]
+
+In our experiments, we have found that working in matrix notation, rather than the
+vectorized approach of Chi and Lange [-@Chi:2015], yields code which is faster as
+well as more easily maintained.
+
+We then analyze this problem in a matrix analogue of the scaled form ADMM presented
+in Section 3.1.1 of Boyd *et al* [-@Boyd:2011]: 
+
+\[\begin{align*}
+U^{(k + 1)} &= \text{arg min}_U \frac{1}{2}\|U - X\|_F^2 + \frac{\rho}{2}\|DU - V^{(k)} + Z^{(k)}\|_F^2 \\
+V^{(k + 1)} &= \text{arg min}_V \lambda\|V\|_{q, 1} + \frac{\rho}{2}\|DU^{(k + 1)} - V + Z^{(k)}\|_F^2 \\
+Z^{(k + 1)} &= Z^{(k)} + DU^{(k+1)} - V^{(k+1)}
+\end{align*}\]
+
+Note that our matrix variables $U, V, Z$ correspond to Boyd *et al.*'s vector variables
+$x, z, u$. 
+
+The first problem can be solved exactly by relatively simple algebra. We note that 
+the Frobenius norm terms can be combined to express the problem as 
+\[\begin{align*}
+\text{arg min}_U & \frac{1}{2}\|U - X\|_F^2 + \frac{1}{2}\|\sqrt{\rho} * (DU - V^{(k)} + Z^{(k)})\|_F^2 \\
+\text{arg min}_U & \frac{1}{2}\left\|\begin{pmatrix} I \\ \sqrt{\rho}D\end{pmatrix} U - \begin{pmatrix} X \\ \sqrt{\rho}(V^{(k)} - Z^{(k)}) \end{pmatrix}\right\|_F^2
+\end{align*}\]
+
+This latter term is essentially a multi-response (ridge) regression problem and has
+an analytical solution given by: 
+\[\left(\begin{pmatrix} I \\ \sqrt{\rho}D \end{pmatrix}^T\begin{pmatrix} I \\ \sqrt{\rho}D \end{pmatrix}\right)^{-1}\begin{pmatrix} I \\ \sqrt{\rho}D \end{pmatrix}^T\begin{pmatrix} X \\ \sqrt{\rho}(V^{(k)} - Z^{(k)}) \end{pmatrix} = \left(I + \rho D^TD\right)^{-1}\left[X + \rho D^T\left(V^{(k)} - Z^{(k)}\right)\right]\]
+
+Next, we note that the $V^{(k)}$ can be expressed in terms of a proximal operator: 
+\[\text{arg min}_V \lambda \|V\|_{q, 1} + \frac{\rho}{2}\|DU^{(k + 1)} - V + Z^{(k)}\|_F^2 = \textsf{prox}_{\|\cdot\|_{q, 1} * \lambda/\rho}(DU^{(k + 1)} + Z^{(k)})\]
+where the matrix norm $\|\cdot\|_{q, 1}$ is the sum of the $\ell_q$-norm of each row.
+Since this norm is separable across rows, evaluation of the overall proximal operator
+can be reduced to evaluation of the proximal operator of the $\ell_q$-norm. 
+
+`clustRviz` currently only supports the $q = 1, 2$ cases, which have closed form solutions: 
+\[V^{(k +1)}_{ij} = \textsf{SoftThresh}_{\lambda/\rho}\left((DU^{(k+1)} + Z^{(k)})_{ij}\right) \text{ when } q = 1\]
+and 
+\[V^{(k +1)}_{i\cdot} = \left(1 - \frac{\lambda}{\rho \|(DU^{(k + 1)} + Z^{(k)})_{i\cdot}\|_2}\right)_+(DU^{(k + 1)} + Z^{(k)})_{i\cdot}\text{ when } q = 2\]
+
+
+The $Z^{(k)}$ update is trivial.
+
+The combined algorithm is thus given by: 
+\[\begin{align*}
+U^{(k + 1)} &= (I + \rho D^TD)^{-1}\left[X + \rho D^T*(V^{(k)} - Z^{(k)})\right]\\
+V^{(k + 1)} &= \textsf{SoftThresh}_{\lambda / \rho}((DU^{(k + 1)} + Z^{(k)})) \\
+Z^{(k + 1)} &= Z^{(k)} + DU^{(k +1)} - V^{(k + 1)}
+\end{align*}\]
+in the $\ell_1$ case and
+\[\begin{align*}
+U^{(k + 1)} &= (I + \rho D^TD)^{-1}\left[X + \rho D^T*(V^{(k)} - Z^{(k)})\right]\\
+V^{(k + 1)}_{i\cdot} &= \left(1 - \frac{\lambda}{\rho \|(DU^{(k + 1)} + Z^{(k)})_{i\cdot}\|_2}\right)_+(DU^{(k + 1)} + Z^{(k)})_{i\cdot} \qquad \text{ for each } i \\
+Z^{(k + 1)} &= Z^{(k)} + DU^{(k +1)} - V^{(k + 1)}
+\end{align*}\] in the $\ell_2$ case.
+
+In practice, we pre-compute a Cholesky factorization of $I + \rho D^TD$ which can 
+be used in each $U$ update.
+
+We use these updates in an algorithmic regularization scheme, as described in
+Hu, Chi, and Allen [-@Hu:2016] to obtain the standard (non-backtracking) `CARP` algorithm: 
+
+- Input:
+    - Data Matrix: $X \in \mathbb{R}^{n \times p}$
+    - Weighted edge set: $\mathcal{E} = \{(e_l, w_l)\}$
+    - Relaxation Parameter: $\rho \in \mathbb{R}_{> 0}$
+- Precompute: 
+    - Difference matrix $D \in \mathbb{R}^{|\mathcal{E}| \times n}$
+    - Cholesky factor $L = \textsf{chol}(I + \rho D^TD) \in \mathbb{R}^{n \times n}$
+- Initialize: 
+    - $U^{(0)} = X$, $V^{(0)} = DX$, $Z^{(0)} = V^{(0)}$, $\gamma^{(1)} = \epsilon$, $k = 1$
+- Repeat until $\|V^{(k - 1)}\| = 0$
+    - $U^{(k)} = L^{-T}L^{-1}\left[X + \rho D^T(V^{(k - 1)} - Z^{(k - 1)})\right]$
+    - If $q = 1$, for all $(i, j)$: \[V_{ij}^{(k)} = \textsf{SoftThreshold}_{w_i \gamma^{(k)}/ \rho}((DU^{(k)} + Z^{(k - 1)})_{ij})\]
+    - If $q = 2$, for all $l$: \[V^{(k)}_{l\cdot} = \left(1 - \frac{\gamma^{(k)} w_l}{\rho\|(DU^{(k)} + Z^{(k - 1)})_{l\cdot}\|_2}\right)_+(DU^{(k)} + Z^{(k - 1)})_{l\cdot}\]
+    - $Z^{(k)} = Z^{(k - 1)} + DU^{(k)} - V^{(k)}$
+    - $\gamma^{(k + 1)} = t \gamma^{(k)}$
+    - $k := k + 1$
+- Return $\{(U^{(l)}, V^{(l)}\}_{l = 0}^{k - 1}$
+
+In `clustRviz`, we do not return the $Z^{(k)}$ iterates, but we do return the 
+$U^{(k)}$ and $V^{(k)}$ iterates, as well as the zero pattern of the latter
+(which is useful for identifying clusters and forming dendrograms).
+
+## Convex Bi-Clustering
+
+`CBASS` begins with the convex biclustering problem originally posed by 
+Chi, Allen, and Baraniuk [-@Chi:2017]:^[Again, we consider the case of uniform weights
+to simplify some of the notation and give the general case at the end of this
+section.]
+
+\[\text{arg min}_{U} \frac{1}{2}\|U - X\|_F^2 + \lambda\left(\sum_{(i, j) \in \mathcal{E_1}} \|U_{i\cdot} - U_{j\cdot}\|_q + \sum_{(k, l) \in \mathcal{E_2}}\|U_{\cdot k} - U_{\cdot l}\|_q\right)\]
+
+As before, we simplify notation by introducing two difference matrices $D_{\text{row}}, D_{\text{col}}$
+to write the problem as: 
+
+\[\text{arg min}_{U} \frac{1}{2}\|U - X\|_F^2 + \lambda\left(\|D_{\text{row}}U\|_{q, 1} + \|UD_{\text{col}}\|_{1, q}\right)\]
+
+We recognize this as the proximal operator of the function $f(U) = \|D_{\text{row}}U\|_{q, 1} + \|UD_{\text{col}}\|_{1, q}$.
+Despite the simplicity of the proximal operators of the individual terms,
+the proximal operator of the sum cannot be computed explicitly. To address this
+difficulty, we use the Dykstra-Like Proximal Algorithm (DLPA) of Bauschke and Combettes
+[-@Bauschke:2008; see also @Combettes:2011] which allows us to evaluate the proximal
+operator of the sum by repeated evaluation of the proximal operators of the summands.
+
+DLPA works by repeating the following iterates until convergence: 
+
+- $T           = \textsf{prox}_{\lambda \|D_{\text{row}}\cdot\|_{q, 1}}(U^{(n)} + P^{(n)})$
+- $P^{(n + 1)} = P^{(n)} + U^{(n)} - T$
+- $U^{(n + 1)} = \textsf{prox}_{\lambda \|\cdot D_{\text{col}}\|_{1, q}}(T + Q^{(n)})$
+- $Q^{(n + 1)} = Q^{(n)} + T - U^{(n + 1)}$
+
+where we initialize $U^{(0)} = X$ and $P^{(0)} = Q^{(0)} = 0$.
+
+The reader may consider $T$ as an intermediate $U$-iterate and denote it as $T = U^{(n + 1/2)}$
+to make its role more clear.
+
+We note that the two proximal operators are non-trivial and require use of an iterative
+algorithm at each evaluation. Thankfully, we have already addressed these problems.
+The first proximal operator can be written as: 
+
+\[\text{arg min}_X \frac{1}{2}\|X - (U^{(n)} + P^{(n)})\|_F^2 + \lambda\|D_{\text{row}}X\|_{q, 1}\]
+
+This is exactly the form of convex clustering, with $X$ serving as the free variable 
+and $U^{(n)} + P^{(n)}$ playing the role of the data. Similarly, the second proximal
+operator can be written as
+
+\[\text{arg min}_X \frac{1}{2}\|X - (T + Q^{(n)})\|_F^2 + \lambda\|XD_{\text{col}}\|_{1, q}\]
+
+This is not quite the problem previously considered, but by transposing everything, 
+noting the invariance of the Frobenius norm under transposition and the duality of the
+$\|\cdot\|_{q, 1}$ and $\|\cdot\|_{1, q}$ norms under transposition, we see that this
+problem is equivalent to: 
+
+\[\text{arg min}_{X^T} \frac{1}{2}\|X^T - (T + Q^{(n)})^T\|_F^2 + \lambda\|D_{\text{col}}^TX^T\|_{q, 1} = \textsf{prox}_{\|D_{\text{col}}^T\cdot\|_{q, 1}}\left[(T + Q^{(n)})^T\right]\]
+
+which is convex clustering of $(T + Q^{(n)})^T$ with the difference matrix $D_{\text{col}}^T$.
+Note also that, since we are minimizing over $X^T$, we are principally interested
+in the transpose of the value of the proximal operator. Putting this together,
+we have the DLPA updates: 
+
+- $T           = \textsf{prox}_{\lambda \|D_{\text{row}}\cdot\|_{q, 1}}(U^{(n)} + P^{(n)})$
+- $P^{(n + 1)} = P^{(n)} + U^{(n)} - T$
+- $U^{(n + 1)} = (\textsf{prox}_{\lambda \|D_{\text{col}}^T\cdot\|_{q, 1}}\left[(T + Q^{(n)})^T\right])^T$
+- $Q^{(n + 1)} = Q^{(n)} + T - U^{(n + 1)}$
+
+In the `CBASS` context, we use an operating splitting scheme to deal with the
+complexity of the $\|A\cdot\|_{q, 1}$-norm proximal operators. In particular, we
+use a single ADMM step, rather than solving the subproblems to convergence, yielding
+the `CBASS` iterates: 
+
+- $T = (I + \rho D_{\text{row}}^TD_{\text{row}})^{-1}\left[U^{(n)} + P^{(n)} + \rho D_{\text{row}}^T\left(V_{\text{row}}^{(n)} - Z_{\text{row}}^{(n)}\right)\right]$ (Row ADMM Primal Update)
+- $V_{\text{row}}^{(n+1)} = \textsf{prox}_{\lambda / \rho\|\cdot\|_{q, 1}}(D_{\text{row}}T + Z_{\text{row}}^{(n)})$ (Row ADMM Copy Update)
+- $Z_{\text{row}}^{(n+1)} = Z^{(n)}_{\text{row}} + D_{\text{row}}T - V^{(n+1)}_{\text{row}}$ (Row ADMM Dual Update)
+- $P^{(n + 1)} = P^{(n)} + U^{(n)} - T$
+- $S = (I + \rho D_{\text{col}}D_{\text{col}}^T)^{-1}\left[(T + Q^{(n)})^T + \rho D_{\text{col}}\left(V_{\text{col}}^{(n)} - Z_{\text{col}}^{(n)}\right)\right]$ (Column ADMM Primal Update)
+- $V_{\text{col}}^{(n+1)} = \textsf{prox}_{\lambda / \rho\|\cdot\|_{q, 1}}(D_{\text{col}}^TS + Z_{\text{col}}^{(n)})$ (Column ADMM Copy Update)
+- $Z_{\text{col}}^{(n+1)} = Z^{(n)}_{\text{col}} + D_{\text{col}}^TS - V^{(n+1)}_{\text{col}}$ (Column ADMM Dual Update)
+- $U^{(n + 1)} = S^T$
+- $Q^{(n + 1)} = Q^{(n)} + T - U^{(n + 1)}$
+
+In practice, we can obtain speed-ups by caching Cholesky factorizations of
+$(I + \rho D_{\text{row}}^TD_{\text{row}})$ and $(I + \rho D_{\text{col}}D_{\text{col}}^T)$
+for repeated use.
+
+Using these updates in an algorthmic regularization scheme [@Hu:2016], we obtain the standard
+(non-backtracking) `CBASS` algorithm:
+
+- Input:
+    - Data Matrix: $X \in \mathbb{R}^{n \times p}$
+    - Weighted edge sets: $\mathcal{E}_{\text{row}} = \{(e_l, w_l)\}$ and $\mathcal{E}_{\text{column}} = \{(e_l, w_l)\}$
+    - Relaxation Parameter: $\rho \in \mathbb{R}_{> 0}$
+- Precompute: 
+    - Row difference matrix $D_{\text{row}} \in \mathbb{R}^{|\mathcal{E}_{\text{row}}| \times n}$
+    - Column difference matrix $D_{\text{col}} \in \mathbb{R}^{p \times |\mathcal{E}_{\text{col}}|}$
+    - Row Cholesky factor $L_{\text{row}} = \textsf{chol}(I + \rho D_{\text{row}}^TD_{\text{row}}) \in \mathbb{R}^{n \times n}$
+    - Column Cholesky factor $L_{\text{col}} = \textsf{chol}(I + \rho D_{\text{col}}D_{\text{col}}^T) \in \mathbb{R}^{p \times p}$
+- Initialize: 
+    - $U^{(0)} = X$, $V^{(0)}_{\text{row}} = D_{\text{row}}X$, $Z^{(0)}_{\text{row}} = V^{(0)}_{\text{row}}$, $V^{(0)}_{\text{col}} = (XD_{\text{col}})^T = D_{\text{col}}^TX^T$, $Z^{(0)}_{\text{col}} = V^{(0)}_{\text{col}}$, $P^{(0)} = Q^{(0)} = 0$, $\gamma^{(1)} = \epsilon$, $k = 0$
+- Repeat until $\|V^{(k - 1)}_{\text{row}}\| = \|V^{(k - 1)}_{\text{col}}\| = 0$
+    - Row Updates: 
+        - $T = L^{-T}_{\text{row}}L^{-1}_{\text{row}}\left[U^{(k)} + P^{(k)} + \rho D^T_{\text{row}}(V^{(k - 1)}_{\text{row}} - Z^{(k - 1)}_{\text{row}})\right]$
+        - If $q = 1$, for all $(i, j)$: \[(V^{(k)}_{\text{row}})_{ij} = \textsf{SoftThreshold}_{w^{\text{row}}_i \gamma^{(k)}/ \rho}((D_{\text{row}}T + Z^{(k - 1)}_{\text{row}})_{ij})\]
+        - If $q = 2$, for all $l$: \[(V^{(k)}_{\text{row}})_{l\cdot} = \left(1 - \frac{\gamma^{(k)} w_l}{\rho\|(D_{\text{row}}T + Z^{(k - 1)}_{\text{row}})_{l\cdot}\|_2}\right)_+(D_{\text{row}}T + Z^{(k - 1)}_{\text{row}})_{l\cdot}\]
+        - $Z^{(k)}_{\text{row}} = Z^{(k - 1)}_{\text{row}} + D_{\text{row}}T - V^{(k)}_{\text{row}}$
+    - $P^{(k)} = P^{(k - 1)} + U^{(k - 1)} - T$
+    - Column Updates: 
+        - $S = L^{-T}_{\text{col}}L^{-1}_{\text{col}}\left[(T + Q^{(k)})^T + \rho D_{\text{col}}(V^{(k - 1)}_{\text{col}} - Z^{(k - 1)}_{\text{col}})\right]$
+        - If $q = 1$, for all $(i, j)$: \[(V^{(k)}_{\text{col}})_{ij} = \textsf{SoftThreshold}_{w^{\text{col}}_i \gamma^{(k)}/ \rho}((D_{\text{col}}^TS + Z^{(k - 1)}_{\text{col}})_{ij})\]
+        - If $q = 2$, for all $l$: \[(V^{(k)}_{\text{col}})_{l\cdot} = \left(1 - \frac{\gamma^{(k)} w_l}{\rho\|(D_{\text{col}}^TS + Z^{(k - 1)}_{\text{col}})_{l\cdot}\|_2}\right)_+(D_{\text{col}}^TS + Z^{(k - 1)}_{\text{col}})_{l\cdot}\]
+        - $Z^{(k)}_{\text{col}} = Z^{(k - 1)}_{\text{col}} + D_{\text{col}}^TS - V^{(k)}_{\text{col}}$
+    - $U^{(k)} = S^T$
+    - $Q^{(k)} = Q^{(k - 1)} + T - U^{(k)}$
+    - $\gamma^{(k + 1)} = t \gamma^{(k)}$
+    - $k := k + 1$
+- Return $\{(U^{(l)}, V^{(l)}_{\text{row}}, V^{(l)}_{\text{col}})\}_{l = 0}^{k - 1}$
+
+Note that, unlike in the `COBRA` algorithm of Chi *et al.* [-@Chi:2017] or the 
+DLPA on which it is based [@Bauschke:2008], we keep the auxiliary ADMM variables 
+$V_{\text{row}}, Z_{\text{row}}, V_{\text{col}}, Z_{\text{col}}$ from one iteration
+to the next, rather than starting each sub-problem *de novo*.
+
+## References

--- a/vignettes/ClustRVizDetails.Rmd
+++ b/vignettes/ClustRVizDetails.Rmd
@@ -105,11 +105,11 @@ Let's begin by loading our package and the dataset:
 library(clustRviz)
 data("presidential_speech")
 Xdat <- presidential_speech
-obs.labels <- rownames(Xdat)
-var.labels <- colnames(Xdat)
+row_labels <- rownames(Xdat)
+col_labels <- colnames(Xdat)
 Xdat[1:5,1:5]
-head(obs.labels)
-head(var.labels)
+head(row_labels)
+head(col_labels)
 ```
 
 ## Preprocessing 
@@ -125,7 +125,7 @@ so we do not scale our data matrix.
 
 ```{r}
 # Centering data before computing the CARP solution path
-Xdat.preprocessed <- scale(Xdat,center=TRUE,scale=FALSE)
+Xdat.preprocessed <- scale(Xdat, center=TRUE, scale=FALSE)
 ```
 
 In the `CARP` function this preprocessing is done via the `X.center` and `X.scale`
@@ -317,19 +317,19 @@ Simiarly to `CARP` objects, `CBASS` clustering solutions may also be extracted v
 three accessor functions. The `CBASS` methods allow one of three parameters to be
 used to specify the solution:
 
-- `k.obs`: the number of observation clusters
-- `k.var`: the number of variable (feature) clusters
+- `k.row`: the number of row clusters
+- `k.col`: the number of column clusters
 - `percent`: the percent of total regularization
 
 Other than this, the behavior of `get_cluster_labels`, and `get_clustered_data`
 is roughly the same:
 
 ```{r}
-# CBASS Cluster Labels for observations (default)
-get_cluster_labels(cbass.fit, percent = 0.85, type = "obs")
+# CBASS Cluster Labels for rows (observations = default)
+get_cluster_labels(cbass.fit, percent = 0.85, type = "row")
 
-# CBASS Cluster Labels for features
-get_cluster_labels(cbass.fit, percent = 0.85, type = "var")
+# CBASS Cluster Labels for columns (features)
+get_cluster_labels(cbass.fit, percent = 0.85, type = "col")
 
 # CBASS Solution - naive centroids
 get_clustered_data(cbass.fit, percent = 0.85)
@@ -339,8 +339,8 @@ get_clustered_data(cbass.fit, percent = 0.85, refit = FALSE)
 ```
 
 The `get_cluster_centroids` function returns a $k_1$-by-$k_2$ matrix, giving
-the (scalar) centroids at a solution with $k_1$ observation clusters and $k_2$
-variable clusters:
+the (scalar) centroids at a solution with $k_1$ row clusters and $k_2$
+column clusters:
 
 ```{r}
 get_cluster_centroids(cbass.fit, percent = 0.85)
@@ -367,7 +367,7 @@ the fusions between observations as regulaization increases.
 To obtain a snapshot we again specify the percent of regularization.
 
 ```{r,fig.width=5,fig.height=5,fig.align='center'}
-plot(carp.fit,type = 'path',percent=.5)
+plot(carp.fit, type = 'path', percent = .5)
 ```
 
 Owing to the CARP-VIZ algorithm, we are also ensured a
@@ -375,7 +375,7 @@ dendrogram representation for the resulting path. In the
 figure below we display the dendrogram of CARP-VIZ:
 
 ```{r,fig.width=5,fig.height=5,fig.align='center'}
-plot(carp.fit,type = 'dendrogram')
+plot(carp.fit, type = 'dendrogram')
 ```
 
 Additional static visualization are available for
@@ -383,7 +383,7 @@ CBASS objects, allowing both static heatmaps and
 dendrograms for observations and variables.
 
 ```{r,echo=TRUE,eval=FALSE}
-plot(cbass.fit,type='var.dendrogram')
+plot(cbass.fit, type = 'col.dendrogram')
 ```
 
 ## Dynamic
@@ -393,17 +393,18 @@ Via the use of Shiny applications, dynamic displays of dendrograms,
 clustering solution paths, and biclustering heatmaps may be easily obtained.
 
 ```{r,echo=TRUE,eval=FALSE}
-plot(carp.fit,type='interactive')
+plot(carp.fit, type = 'interactive')
 ```
 
 ```{r,echo=FALSE,eval=TRUE,out.width='100%'}
-knitr::include_url(url="https://clustrviz.shinyapps.io/PathShiny/",height='850px')
+knitr::include_url(url = "https://clustrviz.shinyapps.io/PathShiny/", 
+                   height = '850px')
 ```
 
 Also for CBASS:
 
 ```{r,echo=TRUE,eval=FALSE}
-plot(cbass.fit,type='interactive')
+plot(cbass.fit, type = 'interactive')
 ```
 
 ## Saving

--- a/vignettes/ClustRVizWeights.rmd
+++ b/vignettes/ClustRVizWeights.rmd
@@ -262,9 +262,9 @@ the raw data matrix.
 
 ### Setting `CBASS` Weights
 
-`CBASS` requires two sets of weights, one for observations and one for features.
-The interface is the same as for `CARP`, but we now can supply the `obs_weights` and
-`var_weights` arguments separately. The former will be used as the `weights`
+`CBASS` requires two sets of weights, one for rows and one for columns.
+The interface is the same as for `CARP`, but we now can supply the `row_weights` and
+`col_weights` arguments separately. The former will be used as the `weights`
 argument to `CARP`; the latter will be used called on the *transpose* of the
 pre-processed data, since it is used to calculate column weights. The weights are
 computed independently (with possibly different choices of $\phi$ and $k$) and
@@ -272,8 +272,8 @@ can be controlled separately: *e.g.*
 
 ```{r message=FALSE}
 CBASS(presidential_speech,
-      var_weights = sparse_rbf_kernel_weights(dist.method = "canberra", k = 4),
-      obs_weights = sparse_rbf_kernel_weights(dist.method = "maximum", phi = 2))
+      col_weights = sparse_rbf_kernel_weights(dist.method = "canberra", k = 4),
+      row_weights = sparse_rbf_kernel_weights(dist.method = "maximum", phi = 2))
 ```
 
 As mentioned above, `CBASS` rescales the resulting weights to ensure proper biclustering.
@@ -342,12 +342,12 @@ Writing the weight scheme as a function is particularly useful for biclustering,
 
 ```{r}
 cbass_chain_fit <- CBASS(presidential_speech,
-                         obs_weights = chain_weights,
-                         var_weights = chain_weights)
+                         row_weights = chain_weights,
+                         col_weights = chain_weights)
 ```
 
 ```{r}
-plot(cbass_chain_fit, type="var.dendrogram")
+plot(cbass_chain_fit, type="col.dendrogram")
 ```
 
 Note that the print method for `CARP` and `CBASS` knows that the weights were

--- a/vignettes/QuickStart.Rmd
+++ b/vignettes/QuickStart.Rmd
@@ -180,7 +180,7 @@ biclustering solutions, and its usage is similar to `CARP`.
 We fit the biclustering solution path as follows:
 
 ```{r}
-cbass.fit <- CBASS(X=Xdat, obs_labels = petrol$No)
+cbass.fit <- CBASS(X=Xdat, row_labels = petrol$No)
 ```
 
 Once fitted, vizualizations are displayed again via the `plot` function.
@@ -191,18 +191,18 @@ of the observations induced by the CBASS solution path.
 plot(cbass.fit)
 ```
 
-Since both observations and variables are clustered simultaneously, a
-cluster dendrogram for the variables may also be plotted:
+Since both rows (observations) and columns (variables) are clustered simultaneously,
+a cluster dendrogram for the columns may also be plotted:
 
-```{r,eval=FALSE}
-plot(cbass.fit,type='var.dendrogram')
+```{r, eval=FALSE}
+plot(cbass.fit, type='col.dendrogram')
 ```
 
 Additionally both dendrograms and the associated cluster heatmap 
 can be viewed by passing the `heatmap` arguement.
 
 ```{r,fig.width=10,fig.height=10,fig.align='center'}
-plot(cbass.fit,type='heatmap')
+plot(cbass.fit, type='heatmap')
 ```
 
 As was the case of `CARP`, interactive visualizations may also be displayed:
@@ -217,26 +217,26 @@ cluster heatmap and dendrogram solutions along the path.
 As was the case with `CARP`, clustering solutions are obtained via the
 `get_cluster_labels` function. The desired clustering solution is specified by:
 
-- the number of observation clusters (`k.obs`);
-- the number of variable clusters (`k.var`); or
+- the number of row clusters (`k.row`);
+- the number of col clusters (`k.col`); or
 - the percent of regularization (`percent`).
 
 In the example below we obtain the biclustering solution
-which obtains $3$ observation clusters:
+which obtains $3$ row clusters:
 
 ```{r}
-# How are the observations clustered at the 3 observation cluster solution?
-table(get_cluster_labels(cbass.fit, k.obs = 3))
+# How are the rows (observations) clustered at the 3 row cluster solution?
+table(get_cluster_labels(cbass.fit, k.row = 3))
 
-# How are the features clustered at the 3 observation cluster solution?
-table(get_cluster_labels(cbass.fit, k.obs = 3, type = "var"))
+# How are the columns (features) clustered at the 3 row cluster solution?
+table(get_cluster_labels(cbass.fit, k.row = 3, type = "col"))
 ```
 
 We can also investigate the bi-clustered data matrix (with the raw data replaced
 by estimated centroids) with the `get_clustered_data` function:
 
 ```{r}
-get_clustered_data(cbass.fit, k.obs = 3)
+get_clustered_data(cbass.fit, k.row = 3)
 ```
 
 Finally we demonstrate how to save the visualizations
@@ -248,21 +248,21 @@ path may be saved via:
 
 ```{r,eval=FALSE}
 saveviz(x=cbass.fit,
-        file.name = 'cbass_vardend_dynamic.png',
-        plot.type = 'var.dendrogram',
+        file.name = 'cbass_column_dendrogram_dynamic.gif',
+        plot.type = 'col.dendrogram',
         image.type = 'dynamic'
 )
 ```
 
 Similarly, a static snapshot of the bicluster heatmap at the moment
-along the path when $4$ observation clusters are formed may be
+along the path when $4$ row clusters are formed may be
 saved also:
 
 ```{r,eval=FALSE}
 saveviz(x=cbass.fit,
-        file.name = 'cbass_heatmap_static_kobs.png',
+        file.name = 'cbass_heatmap_static.png',
         plot.type = 'heatmap',
         image.type = 'static',
-        k.obs = 4
+        k.row = 4
 )
 ```

--- a/vignettes/vignettes.bib
+++ b/vignettes/vignettes.bib
@@ -80,7 +80,32 @@
 @ARTICLE{Nagorski:2018,
   AUTHOR="John Nagorski and Genevera I. Allen",
   TITLE="Genomic Region Detection via Spatial Convex Clustering",
-  JOURNAL="Submitted",
-  URL="https://arxiv.org/abs/1611.04696",
+  JOURNAL="PLoS One",
+  DOI="10.1371/journal.pone.0203007",
+  VOLUME=13,
+  NUMBER=9,
+  PAGES={e0203007},
   YEAR=2018
+}
+
+@ARTICLE{Bauschke:2008,
+  AUTHOR="Heinz H. Bauschke and Patrick L. Combettes",
+  TITLE="A Dykstra-Like Algorithm for Two Monotone Operators",
+  JOURNAL="Pacific Journal of Optimization",
+  YEAR=2008,
+  VOLUME=4,
+  NUMBER=3,
+  PAGES={383-391}
+}
+
+@INCOLLECTION{Combettes:2011,
+  AUTHOR="Patrick L. Combettes and Jean-Cristophe Pesquet",
+  TITLE="Proximal Splitting Methods in Signal Processing",
+  EDITOR="Heinz H. Bauschke and Regina S. Burachik and Patrick L. Combettes and Veit Elser and D. Russell Luke and Henry Wolkowicz",
+  BOOKTITLE="Fixed-Point Algorithms for Inverse Problems in Science and Engineering",
+  PUBLISHER="Springer",
+  YEAR="2011",
+  PAGES="185-212",
+  CHAPTER=10,
+  DOI="10.1007/978-1-4419-9569-8_10"
 }


### PR DESCRIPTION
This is a big PR, which does a couple of things: 

1. It reworks `CARP` and `CBASS` to use a matrix version of
   the algorithms.
2. It adds technical documentation of the matrix algorithm
   (addressing #28)
3. It avoids any internal transposes, so we can replace "obs" and "var"
   with "row" and "col" in a `CBASS` context (#39)

There are a couple of potentially breaking changes here, which I still need to test a bit more: 

- We begin with a row iteration of `CBASS` instead of a column iterations
- The code to identify when fusions occurs is slightly different (but probably better)

In testing, this gets essentially the same results for `CARP` (modulo a problem with a bad fusion identification in the old version), but different results for `CBASS`. I'll play with it a bit
more before merging

@jjn13 I'd really appreciate the benchmarking code (#23) so I can confirm that this still works
with something more than just a "by eye" check. Can you please share that? 