### PR TITLE
Speed Up Graph Connectness Check

### DIFF
--- a/R/weights.R
+++ b/R/weights.R
@@ -79,6 +79,8 @@ make_sparse_weights_func <- function(weight_func){
       dense_weights <- dense_fit$weight_mat
       fit_type      <- dense_fit$type
 
+      check_weight_matrix(dense_weights)
+
       user_k <- (k != "auto")
 
       if (k == "auto") {
@@ -160,7 +162,7 @@ make_sparse_weights_func <- function(weight_func){
 #' weight_func <- dense_rbf_kernel_weights()
 #' weight_func(presidential_speech)
 #'
-#' weight_func <- dense_rbf_kernel_weights(phi=1, dist.method="canberra")
+#' weight_func <- dense_rbf_kernel_weights(phi=0.1, dist.method="canberra")
 #' weight_func(presidential_speech)
 #'
 #' weight_func <- sparse_rbf_kernel_weights()
@@ -214,6 +216,8 @@ dense_rbf_kernel_weights <- function(phi = "auto",
 
     dist_mat <- as.matrix(dist(X, method = dist.method, p = p))
     dist_mat <- exp(-1 * phi * dist_mat^2)
+
+    check_weight_matrix(dist_mat)
 
     diag(dist_mat) <- 0
 

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -122,3 +122,18 @@ test_that("ensure_gif works", {
   expect_equal("~/plot.gif", suppressWarnings(ensure_gif("~/plot.jpg")))
   expect_equal("/my/long/path/plot.gif", suppressWarnings(ensure_gif("/my/long/path/plot.jpg")))
 })
+
+test_that("connectedness check works", {
+  is_connected_adj_mat <- clustRviz:::is_connected_adj_mat
+
+  eye <- function(n) diag(1, nrow = n, ncol = n)
+
+  expect_true(is_connected_adj_mat(eye(1)))
+  expect_false(is_connected_adj_mat(eye(5)))
+
+  A <- eye(3); A[1,2] <- A[2,3] <- A[2,1] <- A[3,2] <- 1
+  expect_true(is_connected_adj_mat(A))
+
+  A <- eye(3); A[1,2] <- A[2,1] <- 1
+  expect_false(is_connected_adj_mat(A))
+})

--- a/tests/testthat/test_weights.R
+++ b/tests/testthat/test_weights.R
@@ -115,3 +115,21 @@ test_that("Print method works - User-Matrix", {
   expect_str_contains(capture_print(clustRviz:::UserMatrix()),
                       "Source: User-Provided Matrix")
 })
+
+test_that("Dense weights connectedness check works", {
+  check_weight_matrix <- clustRviz:::check_weight_matrix
+  eye <- function(n) diag(1, nrow = n, ncol = n)
+
+  W <- eye(3)
+  expect_error(check_weight_matrix(W))
+
+  W <- matrix(1, 3, 3)
+  expect_no_error(check_weight_matrix(W))
+
+  W <- matrix(1, 3, 3); W[1,2] <- W[2,1] <- W[1,3] <- W[3,1] <- 0
+  ## No check for first ob since we are only checking lower triangle
+  expect_error(check_weight_matrix(W), regexp = "observation 2")
+
+  W <- matrix(1, 3, 4)
+  expect_error(check_weight_matrix(W), regexp = "square")
+})


### PR DESCRIPTION
Use C++ DFS rather than adjacency matrix exponentiation to check if graphs are connected. Speed difference is minimal (though possibly marginally improved) for small dense graphs, but
notable for large or sparse graphs.