### PR TITLE
Add U-Smoothing for Convex Clustering

### DIFF
--- a/R/carp.R
+++ b/R/carp.R
@@ -259,7 +259,8 @@ CARP <- function(X,
                                                          v_zero_indices   = carp.sol.path$v_zero_inds,
                                                          labels           = labels,
                                                          dendrogram_scale = dendrogram.scale,
-                                                         npcs             = npcs)
+                                                         npcs             = npcs,
+                                                         smooth_U         = TRUE)
 
   carp.fit <- list(
     X = X.orig,

--- a/R/carp.R
+++ b/R/carp.R
@@ -221,6 +221,7 @@ CARP <- function(X,
   weight_vec <- weight_mat_to_vec(weight_matrix)
 
   crv_message("Computing Convex Clustering [CARP] Path")
+  tic_inner <- Sys.time()
 
   carp.sol.path <- CARPcpp(X,
                            D,
@@ -238,6 +239,8 @@ CARP <- function(X,
                            show_progress = status,
                            back_track = back_track,
                            exact = exact)
+
+  toc_inner <- Sys.time()
 
   ## FIXME - Convert gamma.path to a single column matrix instead of a vector
   ##         RcppArmadillo returns a arma::vec as a n-by-1 matrix
@@ -277,7 +280,8 @@ CARP <- function(X,
     center_vector = center_vector,
     X.scale = X.scale,
     scale_vector = scale_vector,
-    time = Sys.time() - tic
+    time = Sys.time() - tic,
+    fit_time = toc_inner - tic_inner
   )
 
   if (.clustRvizOptionsEnv[["keep_debug_info"]]) {
@@ -332,7 +336,8 @@ print.CARP <- function(x, ...) {
   cat("CARP Fit Summary\n")
   cat("====================\n\n")
   cat("Algorithm:", alg_string, "\n")
-  cat("Time:", sprintf("%2.3f %s", x$time, attr(x$time, "units")), "\n\n")
+  cat("Fit Time:", sprintf("%2.3f %s", x$fit_time, attr(x$fit_time, "units")), "\n")
+  cat("Total Time:", sprintf("%2.3f %s", x$time, attr(x$time, "units")), "\n\n")
 
   cat("Number of Observations:", x$n, "\n")
   cat("Number of Variables:   ", x$p, "\n\n")

--- a/R/cbass.R
+++ b/R/cbass.R
@@ -291,6 +291,7 @@ CBASS <- function(X,
   D_col[cbind(col_edge_list[,2], seq_len(num_edge_cols))] <- -1
 
   crv_message("Computing Convex Bi-Clustering [CBASS] Path")
+  tic_inner <- Sys.time()
 
   cbass.sol.path <- CBASScpp(X,
                              D_row,
@@ -310,6 +311,8 @@ CBASS <- function(X,
                              show_progress = status,
                              back_track = back_track,
                              exact = exact)
+
+  toc_inner <- Sys.time()
 
   ## FIXME - Convert gamma.path to a single column matrix instead of a vector
   ##         RcppArmadillo returns a arma::vec as a n-by-1 matrix
@@ -374,7 +377,8 @@ CBASS <- function(X,
     t = t,
     X.center.global = X.center.global,
     mean_adjust = mean_adjust,
-    time = Sys.time() - tic
+    time = Sys.time() - tic,
+    fit_time = toc_inner - tic_inner
   )
 
   if (.clustRvizOptionsEnv[["keep_debug_info"]]) {
@@ -430,7 +434,8 @@ print.CBASS <- function(x, ...) {
   cat("CBASS Fit Summary\n")
   cat("====================\n\n")
   cat("Algorithm:", alg_string, "\n")
-  cat("Time:", sprintf("%2.3f %s", x$time, attr(x$time, "units")), "\n\n")
+  cat("Fit Time:", sprintf("%2.3f %s", x$fit_time, attr(x$fit_time, "units")), "\n")
+  cat("Total Time:", sprintf("%2.3f %s", x$time, attr(x$time, "units")), "\n\n")
 
   cat("Number of Rows:", x$n, "\n")
   cat("Number of Columns:", x$p, "\n\n")

--- a/R/plot_carp.R
+++ b/R/plot_carp.R
@@ -395,10 +395,11 @@ carp_dendro_plot <- function(x,
   as.dendrogram(x) %>%
     set("branches_lwd", dend.branch.width) %>%
     set("labels_cex", dend.labels.cex) %>%
-    plot(ylab = "Amount of Regularization",
-         cex.lab = dend.ylab.cex,
+    plot(ylab = "Fraction of Regularization",
+         cex.lab = dend.ylab.cex, yaxt = "n",
          ...)
 
+  axis(2, at = c(0, 0.25, 0.5, 0.75, 1), labels = c("0%", "25%", "50%", "75%", "100%"), las=2)
   if(show_clusters){
 
     if(has_percent){

--- a/R/plot_cbass.R
+++ b/R/plot_cbass.R
@@ -376,7 +376,10 @@ cbass_dendro_plot <- function(x,
   as.dendrogram(x, type = type) %>%
            set("branches_lwd", dend.branch.width) %>%
            set("labels_cex", dend.labels.cex) %>%
-           plot(ylab = "Amount of Regularization", cex.lab = dend.ylab.cex, ...)
+           plot(ylab = "Fraction of Regularization",
+                cex.lab = dend.ylab.cex, yaxt = "n", ...)
+
+  axis(2, at = c(0, 0.25, 0.5, 0.75, 1), labels = c("0%", "25%", "50%", "75%", "100%"), las=2)
 
   if(show_clusters){
     labels <- get_cluster_labels(x, k.row = k.row, k.col = k.col, percent = percent, type = type)

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -172,3 +172,30 @@ test_that("connectedness check works", {
   A <- eye(3); A[1,2] <- A[2,1] <- 1
   expect_false(is_connected_adj_mat(A))
 })
+
+test_that("U smoothing for CARP works", {
+  set.seed(200)
+
+  N <- 50
+  P <- 30
+
+  U <- array(rnorm(N * P), c(N, P, 1))
+
+  # Fake cluster assignments
+  K <- 5
+  membership <- sample(K, N, replace = TRUE)
+  cluster_info <- list(membership = membership,
+                       csize      = table(membership),
+                       no         = length(unique(membership)))
+
+  U_smoothed <- smooth_u_clustering(U, list(cluster_info))
+
+  for(k in 1:K){
+    u_row_mean <- colMeans(U[membership == k,,1])
+    for(n in 1:N){
+      if(membership[n] == k){
+        expect_equal(U_smoothed[n,,1], u_row_mean)
+      }
+    }
+  }
+})


### PR DESCRIPTION
@jjn13  This partially addresses #63 by "smoothing" the U estimates, as we've discussed. 

I haven't smoothed the `CBASS` estimates yet since our current approach of doing all the post-processing separately doesn't calculate the relevant cluster info... I don't think this is a problem except for the `CBASS` row- and column-path plots which @agenevera thinks we should remove anyways. Thoughts? 