### PR TITLE
Add `libmagickdev-++` to TravisCI Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
   apt:
     packages:
       - cargo
+      - libmagick++-dev
 
 before_install:
   - gcc --version

--- a/build_steps.R
+++ b/build_steps.R
@@ -19,7 +19,7 @@ before_install <- function(){
                          auth_token = Sys.getenv("GITHUB_PAT") %||% devtools::github_pat(FALSE))
 
   cat("INSTALLING TEST DEPENDENCIES -------- \n\n")
-  for(pkg in c("cvxclustr", "cvxbiclustr")){
+  for(pkg in c("cvxclustr", "cvxbiclustr", "gifski", "png")){
     if(!require(pkg, character.only=TRUE)){
       install.packages(pkg)
     }


### PR DESCRIPTION
New versions of the `animation` package depend on
the libmagick (ImageMagick) library, so we need to add
it to our build environment