### PR TITLE
Add Exact Back-Tracking ADMM

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -1,7 +1,7 @@
 ## clustRviz options
 
 clustRviz_default_options <- list(rho                = 1.0,
-                                  max_iter           = 10000L,
+                                  max_iter           = as.integer(5e6),
                                   burn_in            = 50L,
                                   viz_initial_step   = 1.1,
                                   viz_small_step     = 1.01,

--- a/src/alg_reg_policies.h
+++ b/src/alg_reg_policies.h
@@ -124,7 +124,7 @@ public:
       problem.save_old_values();
 
       bool rep_iter = true;
-      Eigen::Index try_iter = 0;
+      int try_iter = 0;
       double gamma_upper = gamma;
       double gamma_lower = gamma_old;
 

--- a/src/clustRviz.cpp
+++ b/src/clustRviz.cpp
@@ -1,139 +1,99 @@
 #include "clustRviz.h"
 
 // [[Rcpp::export]]
-Rcpp::List CARP_VIZcpp(const Eigen::MatrixXd& X,
-                       const Eigen::MatrixXd& D,
-                       double epsilon,
-                       const Eigen::VectorXd& weights,
-                       double rho              = 1,
-                       int max_iter            = 10000,
-                       int burn_in             = 50,
-                       double back             = 0.5,
-                       int keep                = 10,
-                       int viz_max_inner_iter  = 15,
-                       double viz_initial_step = 1.1,
-                       double viz_small_step   = 1.01,
-                       bool l1                 = false,
-                       bool show_progress      = true){
-
-  ConvexClustering problem(X, D, weights, rho, l1, show_progress);
-  CARP_VIZ carp_viz(problem,
-                    epsilon,
-                    max_iter,
-                    burn_in,
-                    back,
-                    keep,
-                    viz_max_inner_iter,
-                    viz_initial_step,
-                    viz_small_step);
-
-  return carp_viz.build_return_object();
-}
-
-// [[Rcpp::export]]
 Rcpp::List CARPcpp(const Eigen::MatrixXd& X,
                    const Eigen::MatrixXd& D,
+                   const Eigen::VectorXd& weights,
                    double epsilon,
                    double t,
-                   const Eigen::VectorXd& weights,
-                   double rho   = 1,
-                   int max_iter = 10000,
-                   int burn_in  = 50,
-                   int keep     = 10,
-                   bool l1      = false,
-                   bool show_progress = true){
+                   double rho              = 1,
+                   int max_iter            = 10000,
+                   int burn_in             = 50,
+                   double back             = 0.5,
+                   int keep                = 10,
+                   int viz_max_inner_iter  = 15,
+                   double viz_initial_step = 1.1,
+                   double viz_small_step   = 1.01,
+                   bool l1                 = false,
+                   bool show_progress      = true,
+                   bool back_track         = false,
+                   bool exact              = false){
 
   ConvexClustering problem(X, D, weights, rho, l1, show_progress);
-  CARP carp(problem, epsilon, t, max_iter, burn_in, keep);
 
-  return carp.build_return_object();
-}
+  if(exact){
+    if(back_track){
+      ClustRVizLogger::error("Exact ADMM with back-tracking is not yet implemented.");
+    } else {
+      ConvexClusteringADMM admm(problem, epsilon, t, max_iter);
+      return admm.build_return_object();
+    }
+  } else {
+    if(back_track){
+      CARP_VIZ carp_viz(problem,
+                        epsilon,
+                        max_iter,
+                        burn_in,
+                        back,
+                        keep,
+                        viz_max_inner_iter,
+                        viz_initial_step,
+                        viz_small_step);
 
-// [[Rcpp::export]]
-Rcpp::List ConvexClusteringADMMcpp(const Eigen::MatrixXd& X,
-                                   const Eigen::MatrixXd& D,
-                                   double epsilon,
-                                   double t,
-                                   const Eigen::VectorXd& weights,
-                                   double rho   = 1,
-                                   int max_iter = 10000,
-                                   bool l1      = false,
-                                   bool show_progress = true){
+      return carp_viz.build_return_object();
+    }
 
-  ConvexClustering problem(X, D, weights, rho, l1, show_progress);
-  ConvexClusteringADMM admm(problem, epsilon, t, max_iter);
-
-  return admm.build_return_object();
-}
-
-// [[Rcpp::export]]
-Rcpp::List CBASS_VIZcpp(const Eigen::MatrixXd& X,
-                        const Eigen::MatrixXd& D_row,
-                        const Eigen::MatrixXd& D_col,
-                        double epsilon,
-                        const Eigen::VectorXd& weights_col,
-                        const Eigen::VectorXd& weights_row,
-                        double rho              = 1,
-                        int max_iter            = 10000,
-                        int burn_in             = 50,
-                        double back             = 0.5,
-                        int keep                = 10,
-                        int viz_max_inner_iter  = 15,
-                        double viz_initial_step = 1.1,
-                        double viz_small_step   = 1.01,
-                        bool l1                 = false,
-                        bool show_progress      = true){
-
-  ConvexBiClustering problem(X, D_row, D_col, weights_row, weights_col, rho, l1, show_progress);
-  CBASS_VIZ cbass_viz(problem,
-                      epsilon,
-                      max_iter,
-                      burn_in,
-                      back,
-                      keep,
-                      viz_max_inner_iter,
-                      viz_initial_step,
-                      viz_small_step);
-
-  return cbass_viz.build_return_object();
+    CARP carp(problem, epsilon, t, max_iter, burn_in, keep);
+    return carp.build_return_object();
+  }
 }
 
 // [[Rcpp::export]]
 Rcpp::List CBASScpp(const Eigen::MatrixXd& X,
                     const Eigen::MatrixXd& D_row,
                     const Eigen::MatrixXd& D_col,
+                    const Eigen::VectorXd& weights_col,
+                    const Eigen::VectorXd& weights_row,
                     double epsilon,
                     double t,
-                    const Eigen::VectorXd& weights_row,
-                    const Eigen::VectorXd& weights_col,
-                    double rho   = 1,
-                    int max_iter = 1e4,
-                    int burn_in  = 50,
-                    int keep     = 10,
-                    bool l1      = false,
-                    bool show_progress = true){
+                    double rho              = 1,
+                    int max_iter            = 10000,
+                    int burn_in             = 50,
+                    double back             = 0.5,
+                    int keep                = 10,
+                    int viz_max_inner_iter  = 15,
+                    double viz_initial_step = 1.1,
+                    double viz_small_step   = 1.01,
+                    bool l1                 = false,
+                    bool show_progress      = true,
+                    bool back_track         = false,
+                    bool exact              = false){
 
   ConvexBiClustering problem(X, D_row, D_col, weights_row, weights_col, rho, l1, show_progress);
-  CBASS cbass(problem, epsilon, t, max_iter, burn_in, keep);
 
-  return cbass.build_return_object();
-}
+  if(exact){
+    if(back_track){
+      ClustRVizLogger::error("Exact DLPA with back-tracking is not yet implemented.");
+    } else {
+      ConvexBiClusteringADMM admm(problem, epsilon, t, max_iter);
+      return admm.build_return_object();
+    }
+  } else {
+    if(back_track){
+      CBASS_VIZ cbass_viz(problem,
+                          epsilon,
+                          max_iter,
+                          burn_in,
+                          back,
+                          keep,
+                          viz_max_inner_iter,
+                          viz_initial_step,
+                          viz_small_step);
 
-// [[Rcpp::export]]
-Rcpp::List ConvexBiClusteringADMMcpp(const Eigen::MatrixXd& X,
-                                     const Eigen::MatrixXd& D_row,
-                                     const Eigen::MatrixXd& D_col,
-                                     double epsilon,
-                                     double t,
-                                     const Eigen::VectorXd& weights_row,
-                                     const Eigen::VectorXd& weights_col,
-                                     double rho   = 1,
-                                     int max_iter = 1e4,
-                                     bool l1      = false,
-                                     bool show_progress = true){
+      return cbass_viz.build_return_object();
+    }
 
-  ConvexBiClustering problem(X, D_row, D_col, weights_row, weights_col, rho, l1, show_progress);
-  ConvexBiClusteringADMM admm(problem, epsilon, t, max_iter);
-
-  return admm.build_return_object();
+    CBASS cbass(problem, epsilon, t, max_iter, burn_in, keep);
+    return cbass.build_return_object();
+  }
 }

--- a/src/clustRviz.cpp
+++ b/src/clustRviz.cpp
@@ -23,7 +23,16 @@ Rcpp::List CARPcpp(const Eigen::MatrixXd& X,
 
   if(exact){
     if(back_track){
-      ClustRVizLogger::error("Exact ADMM with back-tracking is not yet implemented.");
+      ConvexClusteringADMM_VIZ admm_viz(problem,
+                                        epsilon,
+                                        max_iter,
+                                        burn_in,
+                                        back,
+                                        viz_max_inner_iter,
+                                        viz_initial_step,
+                                        viz_small_step);
+
+      return admm_viz.build_return_object();
     } else {
       ConvexClusteringADMM admm(problem, epsilon, t, max_iter);
       return admm.build_return_object();
@@ -73,7 +82,16 @@ Rcpp::List CBASScpp(const Eigen::MatrixXd& X,
 
   if(exact){
     if(back_track){
-      ClustRVizLogger::error("Exact DLPA with back-tracking is not yet implemented.");
+      ConvexBiClusteringADMM_VIZ admm_viz(problem,
+                                          epsilon,
+                                          max_iter,
+                                          burn_in,
+                                          back,
+                                          viz_max_inner_iter,
+                                          viz_initial_step,
+                                          viz_small_step);
+
+      return admm_viz.build_return_object();
     } else {
       ConvexBiClusteringADMM admm(problem, epsilon, t, max_iter);
       return admm.build_return_object();

--- a/src/clustRviz.h
+++ b/src/clustRviz.h
@@ -11,3 +11,5 @@ typedef AlgorithmicRegularizationFixedStepSizePolicy<ConvexBiClustering> CBASS;
 typedef AlgorithmicRegularizationBacktrackingPolicy<ConvexBiClustering> CBASS_VIZ;
 typedef ADMMPolicy<ConvexClustering> ConvexClusteringADMM;
 typedef ADMMPolicy<ConvexBiClustering> ConvexBiClusteringADMM;
+typedef BackTrackingADMMPolicy<ConvexClustering> ConvexClusteringADMM_VIZ;
+typedef BackTrackingADMMPolicy<ConvexBiClustering> ConvexBiClusteringADMM_VIZ;

--- a/src/optim_policies.h
+++ b/src/optim_policies.h
@@ -8,7 +8,7 @@ template <class PROBLEM_TYPE>
 class ADMMPolicy {
   // This is the full-solution ADMM policy
   //
-  // It is pretty straightforwardL just the standard ADMM + a check
+  // It is pretty straightforward: just the standard ADMM + a check
   // (based on the norm of the difference in the V and Z variables) for convergence
   //
   // We store the result of each level of the regularization parameter
@@ -73,6 +73,158 @@ private:
   const int max_iter = 10000;
 
   // Algorithm state
+  int iter = 0;
+  bool solved = false;
+};
+
+template <class PROBLEM_TYPE>
+class BackTrackingADMMPolicy {
+  // This is the full-solution ADMM policy combined with VIZ-style back-tracking
+public:
+  BackTrackingADMMPolicy(PROBLEM_TYPE problem_,
+                         const double epsilon_,
+                         const int max_iter_,
+                         const int burn_in_,
+                         const double back_,
+                         const int viz_max_inner_iter_,
+                         const double viz_initial_step_,
+                         const double viz_small_step_):
+
+  problem(problem_),
+  epsilon(epsilon_),
+  max_iter(max_iter_),
+  burn_in(burn_in_),
+  back(back_),
+  viz_max_inner_iter(viz_max_inner_iter_),
+  viz_initial_step(viz_initial_step_),
+  viz_small_step(viz_small_step_){};
+
+  void solve(){
+    // We need to keep an eye on gamma for back-tracking purposes
+    double gamma     = epsilon;
+    double gamma_old = epsilon;
+
+    // The PROBLEM_TYPE constructor already stores the gamma = 0 solution,
+    // so we start by setting gamma to gamma and performing an exact solve.
+    problem.gamma = gamma;
+    t = viz_initial_step;
+
+    while( (iter < max_iter) & (!problem.is_complete()) ){
+      ClustRVizLogger::info("Beginning iteration k = ") << iter + 1;
+      ClustRVizLogger::info("gamma = ") << problem.gamma;
+
+      int k = 0;
+
+      // Save fusions to determine if we need to back-track
+      problem.save_fusions();
+
+      bool rep_iter = true;
+      int try_iter = 0;
+      double gamma_upper = gamma;
+      double gamma_lower = gamma_old;
+
+      while(rep_iter){
+
+        // Run ADMM till convergence
+        // Before running the ADMM, we need to reset the auxiliary variables each time.
+        problem.gamma = gamma;
+        problem.reset_aux();
+        do {
+          problem.save_old_values();
+          problem.full_admm_step();
+          iter++; k++;
+
+          // problem.tick() will check for interrupts
+          problem.tick(iter);
+
+          if(k > 150){
+            break; // Avoid infinite loops on a single gamma...
+          }
+
+        } while (!problem.admm_converged());
+
+        ClustRVizLogger::info("ADMM converged with gamma = ") << problem.gamma << " after " << iter << " total iterations.";
+
+        try_iter++;
+        if(try_iter > viz_max_inner_iter){
+          break;
+        }
+
+        // Now that we've converged, we begin the back-tracking (VIZ) checks
+        // This is the core "*-VIZ" logic
+        //
+        // After running the ADMM, instead of proceeding with a fixed step-size update,
+        // we include a back-tracking step
+        if( (!problem.is_interesting_iter()) & (try_iter == 1) ){
+          // If the sparsity pattern (number of fusions) hasn't changed, we have
+          // no need to back-track (we didn't miss any fusions) so we can go immediately
+          // to the next iteration.
+          rep_iter = false;
+          ClustRVizLogger::info("No fusions identified -- continuing to next step.");
+        } else if(problem.multiple_fusions()){
+          // If we see two (or more) new fusions, we need to back-track and figure
+          // out which one occured first
+          problem.load_old_fusions();
+          if(try_iter == 1){
+            gamma = 0.5 * (gamma_lower + gamma_upper);
+          } else{
+            gamma_upper = gamma;
+            gamma = 0.5 * (gamma_lower + gamma_upper);
+          }
+          ClustRVizLogger::info("Too many fusions -- backtracking.");
+        } else if(!problem.is_interesting_iter()){
+          // If we don't observe any new fusions, we move our regularization level
+          // up to try to find one
+          problem.load_old_fusions();
+          gamma_lower = gamma;
+          gamma = 0.5 * (gamma_lower + gamma_upper);
+          ClustRVizLogger::info("Fusion not isolated -- moving forward.");
+        } else {
+          // If we see exactly one new fusion, we have a good step size and exit
+          // the inner back-tracking loop
+          rep_iter = false;
+          ClustRVizLogger::info("Good iteration - continuing to next step.");
+        }
+      }
+
+      // We always store the final iterate of a back-tracking search
+      problem.store_values();
+
+      gamma_old = gamma; // Save this for future back-tracking iterations
+
+      // If we have gotten to the "lots of fusions" part of the solution space, start
+      // taking smaller step sizes.
+      if(problem.has_fusions()){
+        t = viz_small_step;
+      }
+
+      gamma *= t;
+    }
+
+    if(iter >= max_iter){
+      ClustRVizLogger::warning("Clustering ended early -- `max_iter` reached. Treat results with caution.");
+    }
+
+    solved = true;
+  }
+
+  Rcpp::List build_return_object(){
+    if(!solved) solve();
+
+    return problem.build_return_object();
+  }
+private:
+  PROBLEM_TYPE problem;
+  const double epsilon;
+  const int max_iter = 10000;
+  const int burn_in  = 50;
+  const double back  = 0.5;
+  const int viz_max_inner_iter  = 15;
+  const double viz_initial_step = 1.1;
+  const double viz_small_step   = 1.01;
+
+  // Algorithm state
+  double t;
   int iter = 0;
   bool solved = false;
 };

--- a/tests/testthat/test_admm.R
+++ b/tests/testthat/test_admm.R
@@ -26,6 +26,32 @@ test_that("Full ADMM converges for CARP", {
   }
 })
 
+test_that("Full Back-Tracking ADMM converges for CARP", {
+  skip_on_cran()
+  skip_if_not_installed("cvxclustr")
+  data(mammals, package = "cvxclustr")
+
+  ## Example modified from help pages of cvxclustr
+  X <- as.matrix(mammals[,-1])
+  carp_fit <- CARP(X, exact = TRUE, back_track = TRUE, X.center = FALSE, X.scale = FALSE)
+
+  ## Calculate matching `cvxclustr` solution
+  Xt <- t(X)
+
+  ## Match CARP() selected weights
+  w <- clustRviz:::weight_mat_to_vec(carp_fit$weights)
+  gamma <- unique(carp_fit$cluster_membership$Gamma)
+
+  ## Perform clustering
+  suppressWarnings(cvxclust_fit <- cvxclustr::cvxclust(Xt, w, gamma, tol = 1e-7))
+
+  ## cvxclustr seems to use a pretty loose stopping tolerance, so this is a loose check...
+  for(i in seq_along(gamma)){
+    expect_equal(carp_fit$U[,,i], t(cvxclust_fit$U[[i]]),
+                 check.attributes = FALSE, tolerance = 1e-4)
+  }
+})
+
 test_that("Full ADMM converges for CBASS", {
   skip_on_cran()
   skip_if_not_installed("cvxclustr")

--- a/tests/testthat/test_admm.R
+++ b/tests/testthat/test_admm.R
@@ -7,7 +7,7 @@ test_that("Full ADMM converges for CARP", {
 
   ## Example modified from help pages of cvxclustr
   X <- as.matrix(mammals[,-1])
-  carp_fit <- CARP(X, alg.type = "admm", X.center = FALSE, X.scale = FALSE)
+  carp_fit <- CARP(X, exact = TRUE, X.center = FALSE, X.scale = FALSE)
 
   ## Calculate matching `cvxclustr` solution
   Xt <- t(X)
@@ -39,7 +39,7 @@ test_that("Full ADMM converges for CBASS", {
 
   ## Example modified from help pages of cvxclustr
   X <- as.matrix(mammals[,-1])
-  cbass_fit <- CBASS(X, alg.type = "admm", X.center.global = FALSE, t = 1.05)
+  cbass_fit <- CBASS(X, exact = TRUE, X.center.global = FALSE, t = 1.05)
 
   cbass_gamma <- cbass_fit$debug$path$gamma_path
   cbass_U     <- array(cbass_fit$debug$path$u_path, c(NROW(X), NCOL(X), length(cbass_gamma)))

--- a/tests/testthat/test_carp_accessors.R
+++ b/tests/testthat/test_carp_accessors.R
@@ -202,12 +202,12 @@ test_that("CARP cluster centroids are correctly calculated with refit = FALSE", 
     }
   }
 
-  ## Column-wise standard deviations are decreasing
+  ## Column-wise standard deviations are decreasing (or at least non-increasing)
   colSds <- function(x) apply(x, 2, sd)
   for(pct in seq(0.1, 1, length.out = 10)){
     for(carp_fit in carp_fits){
-      expect_gt(sum(colSds(get_clustered_data(carp_fit, percent = pct - 0.1, refit = FALSE))),
-                sum(colSds(get_clustered_data(carp_fit, percent = pct, refit = FALSE))))
+      expect_gte(sum(colSds(get_clustered_data(carp_fit, percent = pct - 0.1, refit = FALSE))),
+                 sum(colSds(get_clustered_data(carp_fit, percent = pct, refit = FALSE))))
     }
   }
 })

--- a/tests/testthat/test_carp_error_handling.R
+++ b/tests/testthat/test_carp_error_handling.R
@@ -22,10 +22,17 @@ test_that("CARP() errors early with incorrect input", {
   expect_error(CARP(presidential_speech, ncores = 0L))
   expect_error(CARP(presidential_speech, ncores = -1L))
 
-  # Must use a known algorithm
-  expect_error(CARP(presidential_speech, alg.type = "unknown"))
-  expect_error(CARP(presidential_speech, alg.type = NA))
-  expect_error(CARP(presidential_speech, alg.type = "CARP"))
+  # Check `exact` argument
+  expect_error(CARP(presidential_speech, exact = "unknown"))
+  expect_error(CARP(presidential_speech, exact = NA))
+  expect_error(CARP(presidential_speech, exact = c(TRUE, FALSE)))
+  expect_error(CARP(presidential_speech, exact = 1L))
+
+  # Check `back_track` argument
+  expect_error(CARP(presidential_speech, back_track = "unknown"))
+  expect_error(CARP(presidential_speech, back_track = NA))
+  expect_error(CARP(presidential_speech, back_track = c(TRUE, FALSE)))
+  expect_error(CARP(presidential_speech, back_track = 1L))
 
   # Must use a t > 1
   expect_error(CARP(presidential_speech, t = 1))

--- a/tests/testthat/test_carp_print.R
+++ b/tests/testthat/test_carp_print.R
@@ -4,7 +4,7 @@ test_that("print.CARP works for default settings", {
     carp_fit <- CARP(presidential_speech)
     carp_print <- capture_print(carp_fit)
 
-    expect_str_contains(carp_print, "Algorithm:[ ]+CARP-VIZ")
+    expect_str_contains(carp_print, "Algorithm:[ ]+CARP")
     expect_str_contains(carp_print, "Number of Observations:[ ]+44")
     expect_str_contains(carp_print, "Number of Variables:[ ]+75")
     expect_str_contains(carp_print, "Columnwise centering:[ ]+TRUE")
@@ -16,15 +16,15 @@ test_that("print.CARP works for default settings", {
 })
 
 test_that("print.CARP works for other algorithms", {
-  expect_str_contains(capture_print(CARP(presidential_speech, alg.type="carpviz")),
+  expect_str_contains(capture_print(CARP(presidential_speech, back_track = TRUE)),
                       "Algorithm:[ ]+CARP-VIZ")
 
-  expect_str_contains(capture_print(CARP(presidential_speech, alg.type="carpviz", norm = 1)),
-                      "Algorithm:[ ]+CARP-VIZ \\[L1\\]")
+  expect_str_contains(capture_print(CARP(presidential_speech, back_track = TRUE, norm = 1)),
+                      "Algorithm:[ ]+CARP-VIZ \\[Back-Tracking Fusion Search\\] \\[L1\\]")
 
-  expect_str_contains(capture_print(CARP(presidential_speech, alg.type="carp", t=1.5)),
+  expect_str_contains(capture_print(CARP(presidential_speech, back_track = FALSE, t = 1.5)),
                       "Algorithm:[ ]+CARP \\(t = 1.5\\)")
 
-  expect_str_contains(capture_print(CARP(presidential_speech, alg.type="carp", t=1.5, norm = 1)),
+  expect_str_contains(capture_print(CARP(presidential_speech, back_track = FALSE, t = 1.5, norm = 1)),
                       "Algorithm:[ ]+CARP \\(t = 1.5\\) \\[L1\\]")
 })

--- a/tests/testthat/test_carp_smoke.R
+++ b/tests/testthat/test_carp_smoke.R
@@ -2,26 +2,25 @@ context("Smoke tests for CARP")
 
 test_that("CARP-VIZ [L2] works", {
   ## Also smoke test status printing here
-  expect_no_error(carp_fit <- CARP(presidential_speech, alg.type="carpviz", status = TRUE))
+  expect_no_error(carp_fit <- CARP(presidential_speech, back_track = TRUE, status = TRUE))
   expect_no_error(print(carp_fit))
 })
 
 test_that("CARP-VIZ [L1] works", {
-  expect_no_error(carp_fit <- CARP(presidential_speech, alg.type="carpviz", norm = 1))
+  expect_no_error(carp_fit <- CARP(presidential_speech, back_track = TRUE, norm = 1))
   expect_no_error(print(carp_fit))
 })
 
 test_that("CARP [L2] works", {
-  expect_no_error(carp_fit <- CARP(presidential_speech, alg.type="carp", t=1.2))
-  expect_no_error(CARP(presidential_speech, alg.type="carp", t=1.1))
-  expect_no_error(CARP(presidential_speech, alg.type="carp", t=1.05))
+  expect_no_error(carp_fit <- CARP(presidential_speech, back_track = FALSE, t = 1.2))
+  expect_no_error(CARP(presidential_speech, back_track = FALSE, t = 1.1))
+  expect_no_error(CARP(presidential_speech, back_track = FALSE, t = 1.05))
   expect_no_error(print(carp_fit))
 })
 
 test_that("CARP [L1] works", {
-  expect_no_error(carp_fit <- CARP(presidential_speech, alg.type="carp", t=1.2, norm = 1))
-  expect_no_error(CARP(presidential_speech, alg.type="carp", t=1.1, norm = 1))
-  expect_no_error(CARP(presidential_speech, alg.type="carp", t=1.05, norm = 1))
+  expect_no_error(carp_fit <- CARP(presidential_speech, back_track = FALSE, t = 1.2, norm = 1))
+  expect_no_error(CARP(presidential_speech, back_track = FALSE, t =1.1, norm = 1))
+  expect_no_error(CARP(presidential_speech, back_track = FALSE, t = 1.05, norm = 1))
   expect_no_error(print(carp_fit))
 })
-

--- a/tests/testthat/test_carp_sparsity_pattern.R
+++ b/tests/testthat/test_carp_sparsity_pattern.R
@@ -3,7 +3,7 @@ context("Test CARP Sparsity Invariants")
 test_that("CARP begins with no fusions", {
   clustRviz_options(keep_debug_info = TRUE)
 
-  carp_fit <- CARP(presidential_speech, alg.type = 'carp')
+  carp_fit <- CARP(presidential_speech, back_track = FALSE)
   expect_zeros(carp_fit$debug$row$v_zero_indices[, 1])
 
   clustRviz_reset_options()
@@ -12,7 +12,7 @@ test_that("CARP begins with no fusions", {
 test_that("CARP ends with all fusions", {
   clustRviz_options(keep_debug_info = TRUE)
 
-  carp_fit <- CARP(presidential_speech, alg.type = 'carp')
+  carp_fit <- CARP(presidential_speech, back_track = FALSE)
   expect_ones(carp_fit$debug$row$v_zero_indices[, NCOL(carp_fit$debug$row$v_zero_indices)])
 
   clustRviz_reset_options()
@@ -21,7 +21,7 @@ test_that("CARP ends with all fusions", {
 test_that("CARP-VIZ begins with no fusions", {
   clustRviz_options(keep_debug_info = TRUE)
 
-  carp_fit <- CARP(presidential_speech, alg.type = 'carpviz')
+  carp_fit <- CARP(presidential_speech, back_track = TRUE)
   expect_zeros(carp_fit$debug$row$v_zero_indices[, 1])
 
   clustRviz_reset_options()
@@ -30,7 +30,7 @@ test_that("CARP-VIZ begins with no fusions", {
 test_that("CARP-VIZ ends with all fusions", {
   clustRviz_options(keep_debug_info = TRUE)
 
-  carp_fit <- CARP(presidential_speech,alg.type='carpviz')
+  carp_fit <- CARP(presidential_speech, back_track = TRUE)
   expect_ones(carp_fit$debug$row$v_zero_indices[, NCOL(carp_fit$debug$row$v_zero_indices)])
 
   clustRviz_reset_options()
@@ -40,7 +40,7 @@ test_that("CARP begins with no fusions (uniform weights)", {
   clustRviz_options(keep_debug_info = TRUE)
 
   weight_mat <- matrix(1, nrow=NROW(presidential_speech), ncol=NROW(presidential_speech))
-  carp_fit   <- CARP(presidential_speech, weights = weight_mat, alg.type = 'carp')
+  carp_fit   <- CARP(presidential_speech, weights = weight_mat, back_track = FALSE)
   expect_zeros(carp_fit$debug$row$v_zero_indices[, 1])
 
   clustRviz_reset_options()
@@ -50,7 +50,7 @@ test_that("CARP ends with all fusions (uniform weights)", {
   clustRviz_options(keep_debug_info = TRUE)
 
   weight_mat <- matrix(1, nrow=NROW(presidential_speech), ncol=NROW(presidential_speech))
-  carp_fit   <- CARP(presidential_speech, weights = weight_mat, alg.type = 'carp')
+  carp_fit   <- CARP(presidential_speech, weights = weight_mat, back_track = FALSE)
   expect_ones(carp_fit$debug$row$v_zero_indices[, NCOL(carp_fit$debug$row$v_zero_indices)])
 
   clustRviz_reset_options()
@@ -60,7 +60,7 @@ test_that("CARP-VIZ begins with no fusions (uniform weights)", {
   clustRviz_options(keep_debug_info = TRUE)
 
   weight_mat <- matrix(1, nrow=NROW(presidential_speech), ncol=NROW(presidential_speech))
-  carp_fit   <- CARP(presidential_speech, weights = weight_mat, alg.type = 'carpviz')
+  carp_fit   <- CARP(presidential_speech, weights = weight_mat, back_track = TRUE)
   expect_zeros(carp_fit$debug$row$v_zero_indices[, 1])
 
   clustRviz_reset_options()
@@ -70,7 +70,7 @@ test_that("CARP-VIZ ends with all fusions (uniform weights)", {
   clustRviz_options(keep_debug_info = TRUE)
 
   weight_mat <- matrix(1, nrow=NROW(presidential_speech), ncol=NROW(presidential_speech))
-  carp_fit   <- CARP(presidential_speech, weights = weight_mat, alg.type = 'carpviz')
+  carp_fit   <- CARP(presidential_speech, weights = weight_mat, back_track = TRUE)
   expect_ones(carp_fit$debug$row$v_zero_indices[, NCOL(carp_fit$debug$row$v_zero_indices)])
 
   clustRviz_reset_options()

--- a/tests/testthat/test_cbass_error_handling.R
+++ b/tests/testthat/test_cbass_error_handling.R
@@ -19,10 +19,17 @@ test_that("CBASS() errors early with incorrect input", {
   expect_error(CBASS(presidential_speech, ncores = 0L))
   expect_error(CBASS(presidential_speech, ncores = -1L))
 
-  # Must use a known algorithm
-  expect_error(CBASS(presidential_speech, alg.type = "unknown"))
-  expect_error(CBASS(presidential_speech, alg.type = NA))
-  expect_error(CBASS(presidential_speech, alg.type = "CBASS"))
+  # Check `exact` argument
+  expect_error(CARP(presidential_speech, exact = "unknown"))
+  expect_error(CARP(presidential_speech, exact = NA))
+  expect_error(CARP(presidential_speech, exact = c(TRUE, FALSE)))
+  expect_error(CARP(presidential_speech, exact = 1L))
+
+  # Check `back_track` argument
+  expect_error(CARP(presidential_speech, back_track = "unknown"))
+  expect_error(CARP(presidential_speech, back_track = NA))
+  expect_error(CARP(presidential_speech, back_track = c(TRUE, FALSE)))
+  expect_error(CARP(presidential_speech, back_track = 1L))
 
   # Must use a t > 1
   expect_error(CBASS(presidential_speech, t = 1))

--- a/tests/testthat/test_cbass_print.R
+++ b/tests/testthat/test_cbass_print.R
@@ -4,7 +4,7 @@ test_that("print.CBASS works for default settings", {
   cbass_fit <- CBASS(presidential_speech)
   cbass_print <- capture_print(cbass_fit)
 
-  expect_str_contains(cbass_print, "Algorithm:[ ]+CBASS-VIZ")
+  expect_str_contains(cbass_print, "Algorithm:[ ]+CBASS")
   expect_str_contains(cbass_print, "Number of Rows:[ ]+44")
   expect_str_contains(cbass_print, "Number of Columns:[ ]+75")
   expect_str_contains(cbass_print, "Global centering:[ ]+TRUE")
@@ -15,15 +15,15 @@ test_that("print.CBASS works for default settings", {
 })
 
 test_that("print.CBASS works for other algorithms", {
-  expect_str_contains(capture_print(CBASS(presidential_speech, alg.type="cbassviz")),
+  expect_str_contains(capture_print(CBASS(presidential_speech, back_track = TRUE)),
                       "Algorithm:[ ]+CBASS-VIZ")
 
-  expect_str_contains(capture_print(CBASS(presidential_speech, alg.type="cbassviz", norm = 1)),
-                      "Algorithm:[ ]+CBASS-VIZ \\[L1\\]")
+  expect_str_contains(capture_print(CBASS(presidential_speech, back_track = TRUE, norm = 1)),
+                      "Algorithm:[ ]+CBASS-VIZ \\[Back-Tracking Fusion Search\\] \\[L1\\]")
 
-  expect_str_contains(capture_print(CBASS(presidential_speech, alg.type="cbass", t=1.5)),
+  expect_str_contains(capture_print(CBASS(presidential_speech, back_track = FALSE, t = 1.5)),
                       "Algorithm:[ ]+CBASS \\(t = 1.5\\)")
 
-  expect_str_contains(capture_print(CBASS(presidential_speech, alg.type="cbass", t=1.5, norm = 1)),
+  expect_str_contains(capture_print(CBASS(presidential_speech, back_track = FALSE, t = 1.5, norm = 1)),
                       "Algorithm:[ ]+CBASS \\(t = 1.5\\) \\[L1\\]")
 })

--- a/tests/testthat/test_cbass_smoke.R
+++ b/tests/testthat/test_cbass_smoke.R
@@ -1,26 +1,26 @@
 context("Smoke tests for CBASS")
 
 test_that("CBASS-VIZ [L2] works", {
-  expect_no_error(cbass_fit <- CBASS(presidential_speech, alg.type="cbassviz"))
+  expect_no_error(cbass_fit <- CBASS(presidential_speech, back_track = TRUE))
   expect_no_error(print(cbass_fit))
 })
 
 test_that("CBASS-VIZ [L1] works", {
-  expect_no_error(cbass_fit <- CBASS(presidential_speech, alg.type="cbassviz", norm = 1))
+  expect_no_error(cbass_fit <- CBASS(presidential_speech, back_track = TRUE, norm = 1))
   expect_no_error(print(cbass_fit))
 })
 
 test_that("CBASS [L2] works", {
-  expect_no_error(cbass_fit <- CBASS(presidential_speech, alg.type="cbass", t=1.2))
-  expect_no_error(CBASS(presidential_speech, alg.type="cbass", t=1.1))
-  expect_no_error(CBASS(presidential_speech, alg.type="cbass", t=1.05))
+  expect_no_error(cbass_fit <- CBASS(presidential_speech, back_track = FALSE, t = 1.2))
+  expect_no_error(CBASS(presidential_speech, back_track = FALSE, t = 1.1))
+  expect_no_error(CBASS(presidential_speech, back_track = FALSE, t = 1.05))
   expect_no_error(print(cbass_fit))
 })
 
 test_that("CBASS [L1] works", {
-  expect_no_error(cbass_fit <- CBASS(presidential_speech, alg.type="cbass", t=1.2, norm = 1))
-  expect_no_error(CBASS(presidential_speech, alg.type="cbass", t=1.1, norm = 1))
-  expect_no_error(CBASS(presidential_speech, alg.type="cbass", t=1.05, norm = 1))
+  expect_no_error(cbass_fit <- CBASS(presidential_speech, back_track = FALSE, t = 1.2, norm = 1))
+  expect_no_error(CBASS(presidential_speech, back_track = FALSE, t = 1.1, norm = 1))
+  expect_no_error(CBASS(presidential_speech, back_track = FALSE, t = 1.05, norm = 1))
   expect_no_error(print(cbass_fit))
 })
 

--- a/tests/testthat/test_cbass_sparsity_pattern.R
+++ b/tests/testthat/test_cbass_sparsity_pattern.R
@@ -3,7 +3,7 @@ context("Test CBASS Sparsity Invariants")
 test_that("CBASS begins with no fusions", {
   clustRviz_options(keep_debug_info = TRUE)
 
-  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbass')
+  cbass_fit <- CBASS(presidential_speech, back_track = FALSE)
   expect_zeros(cbass_fit$debug$row$v_zero_indices[, 1])
   expect_zeros(cbass_fit$debug$col$v_zero_indices[, 1])
 
@@ -13,7 +13,7 @@ test_that("CBASS begins with no fusions", {
 test_that("CBASS ends with full fusions", {
   clustRviz_options(keep_debug_info = TRUE)
 
-  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbass')
+  cbass_fit <- CBASS(presidential_speech, back_track = FALSE)
   expect_ones(cbass_fit$debug$row$v_zero_indices[, NCOL(cbass_fit$debug$row$v_zero_indices)])
   expect_ones(cbass_fit$debug$col$v_zero_indices[, NCOL(cbass_fit$debug$col$v_zero_indices)])
 
@@ -23,7 +23,7 @@ test_that("CBASS ends with full fusions", {
 test_that("CBASS-VIZ begins with no fusions", {
   clustRviz_options(keep_debug_info = TRUE)
 
-  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbassviz')
+  cbass_fit <- CBASS(presidential_speech, back_track = TRUE)
   expect_zeros(cbass_fit$debug$row$v_zero_indices[, 1])
   expect_zeros(cbass_fit$debug$col$v_zero_indices[, 1])
 
@@ -33,7 +33,7 @@ test_that("CBASS-VIZ begins with no fusions", {
 test_that("CBASS-VIZ ends with full fusions", {
   clustRviz_options(keep_debug_info = TRUE)
 
-  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbassviz')
+  cbass_fit <- CBASS(presidential_speech, back_track = TRUE)
   expect_ones(cbass_fit$debug$row$v_zero_indices[, NCOL(cbass_fit$debug$row$v_zero_indices)])
   expect_ones(cbass_fit$debug$col$v_zero_indices[, NCOL(cbass_fit$debug$col$v_zero_indices)])
 
@@ -44,7 +44,7 @@ test_that("CBASS begins with no fusions (uniform weights)", {
   clustRviz_options(keep_debug_info = TRUE)
 
   uniform_weights <- function(X) matrix(1, nrow = NROW(X), ncol = NROW(X))
-  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbass', row_weights = uniform_weights, col_weights = uniform_weights)
+  cbass_fit <- CBASS(presidential_speech, back_track = FALSE, row_weights = uniform_weights, col_weights = uniform_weights)
   expect_zeros(cbass_fit$debug$row$v_zero_indices[, 1])
   expect_zeros(cbass_fit$debug$col$v_zero_indices[, 1])
 
@@ -55,7 +55,7 @@ test_that("CBASS ends with full fusions (uniform weights)", {
   clustRviz_options(keep_debug_info = TRUE)
 
   uniform_weights <- function(X) matrix(1, nrow = NROW(X), ncol = NROW(X))
-  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbass', row_weights = uniform_weights, col_weights = uniform_weights)
+  cbass_fit <- CBASS(presidential_speech, back_track = FALSE, row_weights = uniform_weights, col_weights = uniform_weights)
   expect_ones(cbass_fit$debug$row$v_zero_indices[, NCOL(cbass_fit$debug$row$v_zero_indices)])
   expect_ones(cbass_fit$debug$col$v_zero_indices[, NCOL(cbass_fit$debug$col$v_zero_indices)])
 
@@ -66,7 +66,7 @@ test_that("CBASS-VIZ begins with no fusions (uniform weights)", {
   clustRviz_options(keep_debug_info = TRUE)
 
   uniform_weights <- function(X) matrix(1, nrow = NROW(X), ncol = NROW(X))
-  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbassviz', row_weights = uniform_weights, col_weights = uniform_weights)
+  cbass_fit <- CBASS(presidential_speech, back_track = TRUE, row_weights = uniform_weights, col_weights = uniform_weights)
   expect_zeros(cbass_fit$debug$row$v_zero_indices[, 1])
   expect_zeros(cbass_fit$debug$col$v_zero_indices[, 1])
 
@@ -77,7 +77,7 @@ test_that("CBASS-VIZ ends with full fusions (uniform weights)", {
   clustRviz_options(keep_debug_info = TRUE)
 
   uniform_weights <- function(X) matrix(1, nrow = NROW(X), ncol = NROW(X))
-  cbass_fit <- CBASS(presidential_speech, alg.type = 'cbassviz', row_weights = uniform_weights, col_weights = uniform_weights)
+  cbass_fit <- CBASS(presidential_speech, back_track = TRUE, row_weights = uniform_weights, col_weights = uniform_weights)
   expect_ones(cbass_fit$debug$row$v_zero_indices[, NCOL(cbass_fit$debug$row$v_zero_indices)])
   expect_ones(cbass_fit$debug$col$v_zero_indices[, NCOL(cbass_fit$debug$col$v_zero_indices)])
 

--- a/vignettes/ClustRVizDetails.Rmd
+++ b/vignettes/ClustRVizDetails.Rmd
@@ -181,13 +181,13 @@ In the case of CARP, for example, we may fit the compute the solution
 path for the presidents data via the `CARP` function:
 
 ```{r}
-carp.fit <- CARP(X=Xdat)
+carp_fit <- CARP(X=Xdat)
 ```
 
 Once completed, we can examine a brief summary of the fitted object:
 
 ```{r,message=TRUE}
-carp.fit
+carp_fit
 ```
 
 The output above displays characteristics of our data, such as sample size
@@ -221,42 +221,35 @@ accompaning [weights vignette](ClustRVizWeights.html) for details.
 `CBASS` solutions can be fit in a similar manner:
 
 ```{r}
-cbass.fit <- CBASS(X=Xdat)
+cbass_fit <- CBASS(X=Xdat)
 ```
 
 And display its output:
 ```{r,message=TRUE}
-cbass.fit
+cbass_fit
 ```
 
 ## Algorithm Types
 
 Another input into the fitting procedure is the
-algorithm type. By default both `CARP` and `CBASS` use `VIZ`-type
-extentions of Algorithmic Regularization to ensure dendrogram existence.
-However, for larger datasets ($n.obs > 300$) this default procedure can
-be computationally burdensome. To ameloriate this difficulty, traditional
-Algorithmic Regularization can be used, and it computation time controlled
-via the multiplicitive step-size parameter, $t > 1$.
+algorithm type. By default both `CARP` and `CBASS` a fixed step-size version
+of algorithmic regularization. If the exact dendrogram is of foremost importance, 
+the `VIZ`-type back-tracking extentions may be used by passing `back_track = TRUE`. We
+note, however, that back-tracking may be computationally burdensome, particularly
+for larger data sets. The dendrograms produced by `CARP` and `CBASS` (particularly
+with small step-sizes) are sufficient for the vast majority of applications. 
 
 In the example below we again fit the presidental speech dataset using the
-`carp` algorithim with step size $t=1.1$
+default `carp` algorithim with step size $t=1.1$
 
 ```{r}
-carp_fit_fixed_t <- CARP(Xdat, alg.type = "carp", t = 1.1)
+carp_fit_fixed_t <- CARP(Xdat, t = 1.1)
 carp_fit_fixed_t
 ```
 
-`CBASS` also allows for the use of pure Algorithmic Regularization
-based approaches in a similar manner. Passing `alg.type=cbass` along
-with an associated $t$ value, will produce much faster computations for
-larger datasets.
-
 By default both `CARP` and `CBASS` perform $\ell_2$ regularization between
 observation pairs to encourage fusions, and hence cluster formation. If $\ell_1$
-regularization is preferred for whatever reason, the `alg.type` argument to
-`CARP` can also be `carpvizl1`, for a back-tracking $\ell_1$ algorithm, or
-`carpl1` for a fixed-step-size $\ell_1$ algorithm.
+regularization is preferred for whatever reason, the `norm` argument may be set to `1`.
 
 # Solutions
 
@@ -274,11 +267,11 @@ objects, though the exact meaning of "centroids" varies between the problems
 a `refit` flag, which determines whether the convex clustering centroids or the naive
 centroids (based only on the convex clustering labels) are returned.
 
-For example, we can extract the clustering labels from our `carp.fit` corresponding
+For example, we can extract the clustering labels from our `carp_fit` corresponding
 to a $k = 2$ cluster solution:
 
 ```{r}
-cluster_labels <- get_cluster_labels(carp.fit, k = 2)
+cluster_labels <- get_cluster_labels(carp_fit, k = 2)
 head(cluster_labels)
 ```
 
@@ -291,7 +284,7 @@ table(cluster_labels)
 Similarly, to get the cluster means, we use the `get_cluster_centroids` function:
 
 ```{r}
-get_cluster_centroids(carp.fit, k = 2)
+get_cluster_centroids(carp_fit, k = 2)
 ```
 
 Since we performed convex clustering here, our centroids are $p$-vectors. By default,
@@ -299,7 +292,7 @@ the naive centroids are used; if we prefer the exact convex clustering solution,
 can pass the `refit = FALSE` flag:
 
 ```{r}
-get_cluster_centroids(carp.fit, k = 2, refit = FALSE)
+get_cluster_centroids(carp_fit, k = 2, refit = FALSE)
 ```
 
 We can instead supply the `percent` argument to specify $\lambda$ (or more precisely,
@@ -308,7 +301,7 @@ example, if we are interested at the clustering solution about $25\%$ of the way
 along the regularization path:
 
 ```{r}
-get_cluster_labels(carp.fit, percent = 0.25)
+get_cluster_labels(carp_fit, percent = 0.25)
 ```
 
 We see that our data is clearly falls into three clusters.
@@ -326,16 +319,16 @@ is roughly the same:
 
 ```{r}
 # CBASS Cluster Labels for rows (observations = default)
-get_cluster_labels(cbass.fit, percent = 0.85, type = "row")
+get_cluster_labels(cbass_fit, percent = 0.85, type = "row")
 
 # CBASS Cluster Labels for columns (features)
-get_cluster_labels(cbass.fit, percent = 0.85, type = "col")
+get_cluster_labels(cbass_fit, percent = 0.85, type = "col")
 
 # CBASS Solution - naive centroids
-get_clustered_data(cbass.fit, percent = 0.85)
+get_clustered_data(cbass_fit, percent = 0.85)
 
 # CBASS Solution - convex bi-clustering centroids
-get_clustered_data(cbass.fit, percent = 0.85, refit = FALSE)
+get_clustered_data(cbass_fit, percent = 0.85, refit = FALSE)
 ```
 
 The `get_cluster_centroids` function returns a $k_1$-by-$k_2$ matrix, giving
@@ -343,7 +336,7 @@ the (scalar) centroids at a solution with $k_1$ row clusters and $k_2$
 column clusters:
 
 ```{r}
-get_cluster_centroids(cbass.fit, percent = 0.85)
+get_cluster_centroids(cbass_fit, percent = 0.85)
 ```
 
 # Visualizations
@@ -367,15 +360,13 @@ the fusions between observations as regulaization increases.
 To obtain a snapshot we again specify the percent of regularization.
 
 ```{r,fig.width=5,fig.height=5,fig.align='center'}
-plot(carp.fit, type = 'path', percent = .5)
+plot(carp_fit, type = 'path', percent = .5)
 ```
 
-Owing to the CARP-VIZ algorithm, we are also ensured a
-dendrogram representation for the resulting path. In the
-figure below we display the dendrogram of CARP-VIZ:
+The CARP solution path can be used to construct a dendrogram:
 
 ```{r,fig.width=5,fig.height=5,fig.align='center'}
-plot(carp.fit, type = 'dendrogram')
+plot(carp_fit, type = 'dendrogram')
 ```
 
 Additional static visualization are available for
@@ -383,7 +374,7 @@ CBASS objects, allowing both static heatmaps and
 dendrograms for observations and variables.
 
 ```{r,echo=TRUE,eval=FALSE}
-plot(cbass.fit, type = 'col.dendrogram')
+plot(cbass_fit, type = 'col.dendrogram')
 ```
 
 ## Dynamic
@@ -393,7 +384,7 @@ Via the use of Shiny applications, dynamic displays of dendrograms,
 clustering solution paths, and biclustering heatmaps may be easily obtained.
 
 ```{r,echo=TRUE,eval=FALSE}
-plot(carp.fit, type = 'interactive')
+plot(carp_fit, type = 'interactive')
 ```
 
 ```{r,echo=FALSE,eval=TRUE,out.width='100%'}
@@ -404,7 +395,7 @@ knitr::include_url(url = "https://clustrviz.shinyapps.io/PathShiny/",
 Also for CBASS:
 
 ```{r,echo=TRUE,eval=FALSE}
-plot(cbass.fit, type = 'interactive')
+plot(cbass_fit, type = 'interactive')
 ```
 
 ## Saving
@@ -417,7 +408,7 @@ is sufficient to obtain a visualization along the path:
 
 ```{r,echo=TRUE,eval=FALSE}
 saveviz(
-  carp.fit,
+  carp_fit,
   file.name = 'carp_path_static.png',
   plot.type = 'path',
   image.type = 'static',
@@ -432,7 +423,7 @@ is outputed. In a similar manner, dendrograms may also be easily saved:
 
 ```{r,echo=TRUE,eval=FALSE}
 saveviz(
-  carp.fit,
+  carp_fit,
   file.name = 'carp_dend_static.png',
   plot.type = 'dendrogram',
   image.type = 'static',
@@ -446,7 +437,7 @@ cluster formation.
 
 ```{r,echo=TRUE,eval=FALSE}
 saveviz(
-  carp.fit,
+  carp_fit,
   file.name = 'path_dyn.gif',
   plot.type = 'path',
   image.type = 'dynamic'
@@ -459,7 +450,7 @@ below we save a `.gif` biclustering heatmap.
 
 ```{r,echo=TRUE,eval=FALSE}
 saveviz(
-  cbass.fit,
+  cbass_fit,
   file.name = 'cbass_heat_dyn.gif',
   plot.type = 'heatmap',
   image.type = 'dynamic'


### PR DESCRIPTION
As discussed in #76, this replaces the `alg.type` flag with distinct `exact` and `back_track` arguments to support a back-tracking exact ADMM (very slow!)

It simplifies the C++ entry points a bit, but there's some redundancy between the back-tracking logic for the ADMM and for the AR variants. A bigger restructuring could avoid this, but it's heavy... I'll revisit this after pursuing some other approaches for simplifying the bi-clustering algorithm. (No GH issue for now - the open questions are mathematical, not code related)