### PR TITLE
Fix early termination error message

### DIFF
--- a/src/alg_reg_policies.h
+++ b/src/alg_reg_policies.h
@@ -52,7 +52,7 @@ public:
     }
 
     if(iter >= max_iter){
-      ClustRVizLogger::warning("Clustering ended early -- `max_iter` reached. Treat results with caution.");
+      ClustRVizLogger::error("Clustering ended early -- `max_iter` reached. Treat results with caution.");
     }
 
     solved = true;
@@ -204,7 +204,7 @@ public:
     }
 
     if(iter >= max_iter){
-      ClustRVizLogger::warning("Clustering ended early -- `max_iter` reached. Treat results with caution.");
+      ClustRVizLogger::error("Clustering ended early -- `max_iter` reached. Treat results with caution.");
     }
 
     solved = true;

--- a/src/optim_policies.h
+++ b/src/optim_policies.h
@@ -55,7 +55,7 @@ public:
     }
 
     if(iter >= max_iter){
-      ClustRVizLogger::warning("Clustering ended early -- `max_iter` reached. Treat results with caution.");
+      ClustRVizLogger::error("Clustering ended early -- `max_iter` reached. Treat results with caution.");
     }
 
     solved = true;
@@ -202,7 +202,7 @@ public:
     }
 
     if(iter >= max_iter){
-      ClustRVizLogger::warning("Clustering ended early -- `max_iter` reached. Treat results with caution.");
+      ClustRVizLogger::error("Clustering ended early -- `max_iter` reached. Treat results with caution.");
     }
 
     solved = true;

--- a/tests/testthat/test_carp_misc.R
+++ b/tests/testthat/test_carp_misc.R
@@ -30,3 +30,10 @@ test_that("CARP stores scale factors", {
   expect_equal(carp_fit_no_std$scale_vector, rep(1, NCOL(presidential_speech)))
   expect_equal(carp_fit_no_std$center_vector, rep(0, NCOL(presidential_speech)))
 })
+
+test_that("CARP fails when max_iter reached", {
+  clustRviz_options(max_iter = 400)
+  on.exit(clustRviz_reset_options())
+
+  expect_error(CARP(presidential_speech), "Clustering ended early")
+})

--- a/tests/testthat/test_cbass_misc.R
+++ b/tests/testthat/test_cbass_misc.R
@@ -30,3 +30,12 @@ test_that("CBASS stores mean of original data", {
   cbass_fit <- CBASS(presidential_speech, X.center.global = FALSE)
   expect_equal(0, cbass_fit$mean_adjust)
 })
+
+
+test_that("CBASS fails when max_iter reached", {
+  clustRviz_options(max_iter = 400)
+  on.exit(clustRviz_reset_options())
+
+  expect_error(CBASS(presidential_speech), "Clustering ended early")
+})
+


### PR DESCRIPTION
When CARP/CBASS fail to converge before hitting
the iteration limit, control is returned to R
where dendrogram construction fails with a unintelligible
error message. Instead, fail explicitly at max_iter with a
clearer error message

- Update src/{alg_reg,optim}_policies.h to use ::error
- Add tests