### PR TITLE
Replace `uint` with `unsigned int`

### DIFF
--- a/src/biclustering_impl.h
+++ b/src/biclustering_impl.h
@@ -337,7 +337,7 @@ public:
                               Rcpp::Named("gamma_path")      = gamma_path);
   }
 
-  void tick(uint iter){
+  void tick(unsigned int iter){
     sp.update(nzeros_row + nzeros_col,
               V_row.squaredNorm() + V_col.squaredNorm(),
               iter,

--- a/src/clustering_impl.h
+++ b/src/clustering_impl.h
@@ -165,7 +165,7 @@ public:
                               Rcpp::Named("gamma_path")  = gamma_path);
   }
 
-  void tick(uint iter){
+  void tick(unsigned int iter){
     sp.update(nzeros, V.squaredNorm(), iter, gamma);
   }
 

--- a/src/get_cluster_assignments.cpp
+++ b/src/get_cluster_assignments.cpp
@@ -12,7 +12,7 @@ Rcpp::List get_cluster_assignments_impl(const Eigen::MatrixXi& E,
   std::set<int> all_vertices_seen;
 
   // Iterate over all possible edges - this big loop is a no-op where edge_ind == 0
-  for(uint i = 0; i < edge_ind.size(); i++){
+  for(unsigned int i = 0; i < edge_ind.size(); i++){
 
     if(edge_ind(i) != 0){ // If the edge is present
       int edge_begin = E(i, 0);
@@ -21,7 +21,7 @@ Rcpp::List get_cluster_assignments_impl(const Eigen::MatrixXi& E,
       // We begin by looking for the first vertex (here called "begin") in each component
       bool found_component_begin = false;
 
-      for(uint j = 0; j < components.size(); j++){
+      for(unsigned int j = 0; j < components.size(); j++){
         std::set<int>& component_j = components[j];
 
         if(contains(component_j, edge_begin)){
@@ -38,7 +38,7 @@ Rcpp::List get_cluster_assignments_impl(const Eigen::MatrixXi& E,
           }
 
           // Now check other components
-          for(uint k = 0; k < components.size(); k++){
+          for(unsigned int k = 0; k < components.size(); k++){
             if(k != j){ // We handled k == j above
 
               std::set<int>& component_k = components[k];
@@ -75,7 +75,7 @@ Rcpp::List get_cluster_assignments_impl(const Eigen::MatrixXi& E,
         // If it is, then we add edge_begin to the same component
         bool found_component_end_inner = false;
 
-        for(uint j = 0; j < components.size(); j++){
+        for(unsigned int j = 0; j < components.size(); j++){
           std::set<int>& component_j = components[j];
           if(contains(component_j, edge_end)){
             // We didn't find edge_begin, but we do have edge_end, so let's add
@@ -127,7 +127,7 @@ Rcpp::List get_cluster_assignments_impl(const Eigen::MatrixXi& E,
   // Assign labels - loop over components and then elements within components
   // Requires irregular access to component_indicators, but it's O(1) (=O(n) total) instead
   // of searching through all the sets repeatedly
-  for(uint i = 0; i < components.size(); i++){
+  for(unsigned int i = 0; i < components.size(); i++){
     std::set<int>& component_i = components[i];
     component_sizes[i] = component_i.size();
 

--- a/src/status.h
+++ b/src/status.h
@@ -31,7 +31,7 @@ class StatusPrinter {
 
 public:
   StatusPrinter(bool show_progress,
-                uint total_fusions,
+                unsigned int total_fusions,
                 std::string format = "",
                 int width = Rf_GetOptionWidth() - 2) :
 
@@ -60,7 +60,7 @@ public:
     this->v_norm_init = v_norm_init;
   }
 
-  void update(int fusions_, double v_norm_, uint iter_, double gamma_) {
+  void update(int fusions_, double v_norm_, unsigned int iter_, double gamma_) {
     double time_since_last_tick = (std::clock() - last_tick) / ((double) CLOCKS_PER_SEC);
 
     if(time_since_last_tick < CLUSTRVIZ_STATUS_UPDATE_TIME_SECS){
@@ -70,7 +70,7 @@ public:
     force_update(fusions_, v_norm_, iter_, gamma_);
   }
 
-  void force_update(int fusions_, double v_norm_, uint iter_, double gamma_){
+  void force_update(int fusions_, double v_norm_, unsigned int iter_, double gamma_){
     Rcpp::checkUserInterrupt(); // Check essentially every time we do the progress bar
 
     if(!show_progress){
@@ -99,7 +99,7 @@ public:
 
 private:
   const bool show_progress;    // Do we print output?
-  uint count;                  // Number of times we have updated the printer
+  unsigned int count;          // Number of times we have updated the printer
   const bool output_supported; // Do we support the desired print location?
   std::string format;          // Bar template -- hard coded above
   int width;                   // Width of progress bar (used to set template and control print length)
@@ -107,12 +107,12 @@ private:
   std::clock_t last_tick;      // Time of last PB tick
 
   // ClustRviz-specific measures of progress
-  const uint total_fusions; // Number of edges that need to be fused before termination
-  uint fusions;             // Number of edges fused so far
-  double v_norm_init;       // Initial squared Frobenius norm of V
-  double v_norm;           // Current squared Frobenius norm of V
-  uint iter;               // What iteration we are on
-  double gamma;            // Current regularization level
+  const unsigned int total_fusions; // Number of edges that need to be fused before termination
+  unsigned int fusions;             // Number of edges fused so far
+  double v_norm_init;               // Initial squared Frobenius norm of V
+  double v_norm;                    // Current squared Frobenius norm of V
+  unsigned int iter;                // What iteration we are on
+  double gamma;                     // Current regularization level
 
   void update_format(){
     if(this->width >= 120){

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -120,7 +120,7 @@ Rcpp::NumericVector smooth_u_clustering(Rcpp::NumericVector U_old, Rcpp::List cl
 
   for(Eigen::Index q = 0; q < Q; q++){
     Rcpp::List cluster_info = cluster_info_list[q];
-    uint n_clusters = Rcpp::as<uint>(cluster_info[2]);
+    unsigned int n_clusters = Rcpp::as<unsigned int>(cluster_info[2]);
 
     Rcpp::IntegerVector cluster_ids = cluster_info[0];
     Rcpp::IntegerVector cluster_sizes = cluster_info[1];
@@ -128,11 +128,11 @@ Rcpp::NumericVector smooth_u_clustering(Rcpp::NumericVector U_old, Rcpp::List cl
     Eigen::MatrixXd U_old_slice = Eigen::Map<Eigen::MatrixXd>(&U_old[N * P * q], N, P);
     Eigen::MatrixXd U_new(N, P);
 
-    for(uint j = 1; j <= n_clusters; j++){ // Cluster IDs are 1-based (per R conventions)
+    for(unsigned int j = 1; j <= n_clusters; j++){ // Cluster IDs are 1-based (per R conventions)
       Eigen::VectorXd vec = Eigen::VectorXd::Zero(P);
 
       // Manually work out new mean
-      for(uint n = 0; n < N; n++){
+      for(unsigned int n = 0; n < N; n++){
         if(cluster_ids[n] == j){
           vec += U_old_slice.row(n);
         }
@@ -141,7 +141,7 @@ Rcpp::NumericVector smooth_u_clustering(Rcpp::NumericVector U_old, Rcpp::List cl
       vec /= cluster_sizes[j - 1]; // Subtract 1 to adjust to C++ indexing
 
       // Assign new mean where needed...
-      for(uint n = 0; n < N; n++){
+      for(unsigned int n = 0; n < N; n++){
         if(cluster_ids[n] == j){
           U_new.row(n) = vec;
         }

--- a/vignettes/QuickStart.Rmd
+++ b/vignettes/QuickStart.Rmd
@@ -6,7 +6,7 @@ output:
   rmarkdown::html_vignette:
     css: style.css
 vignette: >
-  %\VignetteIndexEntry{clustRviz Details}
+  %\VignetteIndexEntry{clustRviz Quick Start}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
- Replace `uint` typedef with explicit unsigned int
  since `uint` is not universal (older GCC on Windows)